### PR TITLE
Add support for SQLServer and PostgreSQL in Listening Mode

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -41,7 +41,15 @@
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
+            <artifactId>debezium-connector-sqlserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-oracle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-connector-postgres</artifactId>
         </dependency>
         <dependency>
             <groupId>io.siddhi</groupId>

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -255,8 +255,7 @@ import java.util.concurrent.Executors;
                                 "\ndefine stream inputStream (name string);",
                         description = "In this example, the CDC source polls the 'students' table for inserts " +
                                 "and updates. The polling column is a timestamp field."
-                ),
-
+                )
         }
 )
 

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -41,6 +41,7 @@ public class CDCSourceConstants {
     public static final String CONNECTOR_CLASS = "connector.class";
     public static final String DATABASE_PORT = "database.port";
     public static final String TABLE_WHITELIST = "table.whitelist";
+    public static final String DATABASE_DBNAME = "database.dbname";
     public static final String DATABASE_HOSTNAME = "database.hostname";
     public static final String DATABASE_USER = "database.user";
     public static final String DATABASE_PASSWORD = "database.password";
@@ -48,6 +49,8 @@ public class CDCSourceConstants {
     public static final String CDC_SOURCE_OBJECT = "cdc.source.object";
     public static final String DATABASE_HISTORY = "database.history";
     public static final String MYSQL_CONNECTOR_CLASS = "io.debezium.connector.mysql.MySqlConnector";
+    public static final String POSTGRESQL_CONNECTOR_CLASS = "io.debezium.connector.postgresql.PostgresConnector";
+    public static final String SQLSERVER_CONNECTOR_CLASS = "io.debezium.connector.sqlserver.SqlServerConnector";
     public static final String BEFORE_PREFIX = "before_";
     public static final String CACHE_OBJECT = "cacheObj";
     public static final int DEFAULT_SERVER_ID = -1;

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -73,12 +73,61 @@ public class CDCSourceUtil {
 
                     //Add other MySQL specific details to configMap.
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.MYSQL_CONNECTOR_CLASS);
-
                     break;
                 }
+                case "postgresql": {
+                    //Extract url details
+                    String regex = "jdbc:postgresql://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
+                            "(\\d++)/(\\w*)";
+                    Pattern p = Pattern.compile(regex);
+                    Matcher matcher = p.matcher(url);
+                    if (matcher.find()) {
+                        host = matcher.group(1);
+                        port = Integer.parseInt(matcher.group(2));
+                        database = matcher.group(3);
+                    } else {
+                        throw new WrongConfigurationException("Invalid JDBC url: " + url + " received for stream: " +
+                                siddhiStreamName + ". Expected url format: jdbc:postgresql://<host>:<port>/" +
+                                "<database_name>");
+                    }
+
+                    //Add extracted url details to configMap.
+                    configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
+                    configMap.put(CDCSourceConstants.DATABASE_PORT, port);
+                    configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
+                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+
+                    //Add other PostgreSQL specific details to configMap.
+                    configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.POSTGRESQL_CONNECTOR_CLASS);
+                    break;
+                }
+                case "sqlserver": {
+                    //Extract url details
+                    String regex = "jdbc:sqlserver://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
+                            "(\\d++);databaseName=(\\w*)";
+                    Pattern p = Pattern.compile(regex);
+                    Matcher matcher = p.matcher(url);
+                    if (matcher.find()) {
+                        host = matcher.group(1);
+                        port = Integer.parseInt(matcher.group(2));
+                        database = matcher.group(3);
+                    } else {
+                        throw new WrongConfigurationException("Invalid JDBC url: " + url + " received for stream: " +
+                                siddhiStreamName + ". Expected url format: jdbc:sqlserver://<host>:<port>;" +
+                                "databaseName=<database_name>");
+                    }
+                    //Add extracted url details to configMap.
+                    configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
+                    configMap.put(CDCSourceConstants.DATABASE_PORT, port);
+                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+                    configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
+
+                    //Add other SQLServer specific details to configMap.
+                    configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS);
+                    break;
                 default: {
-                    throw new WrongConfigurationException("Unsupported schema. Expected schema: mysql, Found: "
-                            + splittedURL[1]);
+                    throw new WrongConfigurationException("Unsupported schema. Expected schema: mysql or postgresql" +
+                            "or sqlserver, Found: " + splittedURL[1]);
                 }
             }
 

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -125,6 +125,7 @@ public class CDCSourceUtil {
                     //Add other SQLServer specific details to configMap.
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS);
                     break;
+                }
                 default: {
                     throw new WrongConfigurationException("Unsupported schema. Expected schema: mysql or postgresql" +
                             "or sqlserver, Found: " + splittedURL[1]);

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,16 @@
                 <version>${debezium-connector-oracle.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-postgres</artifactId>
+                <version>${debezium-connector-postgres.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-connector-sqlserver</artifactId>
+                <version>${debezium-connector-sqlserver.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${hikari.version}</version>
@@ -194,6 +204,8 @@
         <debezium-connector-mysql.version>0.9.5.Final</debezium-connector-mysql.version>
         <debezium-embedded.version>0.9.5.Final</debezium-embedded.version>
         <debezium-connector-oracle.version>0.9.5.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>0.9.5.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>0.9.5.Final</debezium-connector-sqlserver.version>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>
         <siddhi-store-rdbms.version>6.0.0</siddhi-store-rdbms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -191,9 +191,9 @@
         <siddhi-map-keyvalue.version>2.0.1</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>0.8.3.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>0.8.3.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>0.8.3.Final</debezium-connector-oracle.version>
+        <debezium-connector-mysql.version>0.9.5.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>0.9.5.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>0.9.5.Final</debezium-connector-oracle.version>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>
         <siddhi-store-rdbms.version>6.0.0</siddhi-store-rdbms.version>


### PR DESCRIPTION
## Purpose
 In the current implementation, only MySQL is supported in listening mode. I am adding support for SQLServer and PostgreSQL.

## Goals
> Bump debezium version to the latest (0.9.5.Final)
> Implement SqlServer Debezium Connector
> Implement PostgreSQL Debezium Connector

## Related PR
These changes are done in 4.x.x branch in https://github.com/siddhi-io/siddhi-io-cdc/pull/18

## Tests
Tested with SP 4.4.0 RC4

## Samples
 SQLServer
@source(type = 'cdc', url = 'jdbc:sqlserver://localhost:1433;databaseName=production1', username = 'sa', password = 'TopSecret', table.name = 'dbo.SweetProductionTable', operation = 'insert', @map(type = 'keyvalue'))
define stream inputStream (name string, amount int);

 PostgreSQL
@source(type = 'cdc', url = 'jdbc:postgresql://localhost:5432/postgres', username = 'postgres', password = 'password', table.name = 'public.SweetFactoryTable', operation = 'insert', @map(type = 'keyvalue'))
define stream inputStream (name string, amount int);


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes