### PR TITLE
Downgrade debezium to fix wso2/streaming-integrator#11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Latest API Docs is <a target="_blank" href="https://siddhi-io.github.io/siddhi-i
 
 
 ## Dependencies 
+JDBC connector jar should be added to the runtime. Download the JDBC connector jar based on the database type that is being used.
 
-There are some prerequisites that need to meet based on the CDC mode used. Please find them below.
+For MySQL, use connector version 5.1.xx.
+
+In addition to that, there are some prerequisites that need to be met based on the CDC mode used. Please find them below.
 
 **Default mode (Listening mode):**
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,11 +201,11 @@
         <siddhi-map-keyvalue.version>2.0.1</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>0.9.5.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>0.9.5.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>0.9.5.Final</debezium-connector-oracle.version>
-        <debezium-connector-postgres.version>0.9.5.Final</debezium-connector-postgres.version>
-        <debezium-connector-sqlserver.version>0.9.5.Final</debezium-connector-sqlserver.version>
+        <debezium-connector-mysql.version>0.8.3.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>0.8.3.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>0.8.3.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>0.8.3.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>0.8.3.Final</debezium-connector-sqlserver.version>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>
         <siddhi-store-rdbms.version>6.0.1</siddhi-store-rdbms.version>


### PR DESCRIPTION
## Purpose
Downgrade debezium to fix https://github.com/wso2/streaming-integrator/issues/11.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- Mysql connector: mysql-connector-java-5.1.45-bin.jar
- mysql-5.7.27-macos10.14-x86_64
- Mac OS 10.13.1 (17B1003)