### PR TITLE
Fix timeout issue while waiting on missed records

### DIFF
--- a/component/src/test/java/org/wso2/extension/siddhi/io/cdc/source/TestCaseOfCDCPollingMode.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/cdc/source/TestCaseOfCDCPollingMode.java
@@ -369,10 +369,10 @@ public class TestCaseOfCDCPollingMode {
 
         // Do inserts and wait CDC app to capture the events.
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
-        Object[] ann = new Object[]{11, "Ann"};
-        Object[] bob = new Object[]{12, "Bob"};
-        Object[] charles = new Object[]{13, "Charles"};
-        Object[] david = new Object[]{14, "David"};
+        Object[] ann = new Object[]{1, "Ann"};
+        Object[] bob = new Object[]{2, "Bob"};
+        Object[] charles = new Object[]{3, "Charles"};
+        Object[] david = new Object[]{4, "David"};
 
         inputHandler.send(ann);
         inputHandler.send(bob);


### PR DESCRIPTION
## Purpose
This PR fixes a wait timeout issue while waiting on missed records. The `missed.record.waiting.timeout` is in seconds, but internally it's used as milliseconds. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi-io-cdc/pull/36