### PR TITLE
Fix listening mode of Oracle CDC

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -75,4 +75,5 @@ public class CDCSourceConstants {
     public static final String ORACLE_OUTSERVER_PROPERTY_NAME = "database.out.server.name";
     public static final String WAIT_ON_MISSED_RECORD = "wait.on.missed.record";
     public static final String MISSED_RECORD_WAITING_TIMEOUT = "missed.record.waiting.timeout";
+    public static final String CONNECTOR_NAME = "name";
 }


### PR DESCRIPTION
## Purpose
This PR fixes the following issues.
- The host in the Oracle JDBC URL accepts only IP addresses. This was fixed by changing the regular expression to extract DNS names as well. And also the database/SID with periods. (Resolves https://github.com/siddhi-io/siddhi-io-cdc/issues/48)
- Unscaled NUMBER datatypes are not decoded properly for Oracle. This was fixed by properly casting the  (Resolves https://github.com/siddhi-io/siddhi-io-cdc/issues/50)
- Made the PDB name an optional parameter when the Oracle database is setup as Standalone.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes