### PR TITLE
Fix JDBC URLs to accept hostnames

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -52,8 +52,7 @@ public class CDCSourceUtil {
             switch (splittedURL[1]) {
                 case "mysql": {
                     //Extract url details
-                    String regex = "jdbc:mysql://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
-                            "(\\d++)/(\\w*)";
+                    String regex = "jdbc:mysql://([a-zA-Z0-9-_\\.]+):(\\d++)/(\\w*)";
                     Pattern p = Pattern.compile(regex);
                     Matcher matcher = p.matcher(url);
                     if (matcher.find()) {
@@ -77,8 +76,7 @@ public class CDCSourceUtil {
                 }
                 case "postgresql": {
                     //Extract url details
-                    String regex = "jdbc:postgresql://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
-                            "(\\d++)/(\\w*)";
+                    String regex = "jdbc:postgresql://([a-zA-Z0-9-_\\.]+):(\\d++)/(\\w*)";
                     Pattern p = Pattern.compile(regex);
                     Matcher matcher = p.matcher(url);
                     if (matcher.find()) {
@@ -103,8 +101,7 @@ public class CDCSourceUtil {
                 }
                 case "sqlserver": {
                     //Extract url details
-                    String regex = "jdbc:sqlserver://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
-                            "(\\d++);databaseName=(\\w*)";
+                    String regex = "jdbc:sqlserver://([a-zA-Z0-9-_\\.]+):(\\d++);databaseName=(\\w*)";
                     Pattern p = Pattern.compile(regex);
                     Matcher matcher = p.matcher(url);
                     if (matcher.find()) {
@@ -162,8 +159,7 @@ public class CDCSourceUtil {
                 case "mongodb": {
                     //Extract url details
                     isMongodb = true;
-                    String regex = "jdbc:mongodb://(\\w*|(\\w*)/[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):" +
-                            "(\\d++)/(\\w*)";
+                    String regex = "jdbc:mongodb://(\\w*|(\\w*)/[a-zA-Z0-9-_\\.]+):(\\d++)/(\\w*)";
                     Pattern p = Pattern.compile(regex);
                     Matcher matcher = p.matcher(url);
                     String replicaSetName;

--- a/component/src/test/java/io/siddhi/extension/io/cdc/source/TestCaseOfCDCSourceValidation.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/source/TestCaseOfCDCSourceValidation.java
@@ -103,7 +103,7 @@ public class TestCaseOfCDCSourceValidation {
 
         SiddhiManager siddhiManager = new SiddhiManager();
 
-        String wrongURL = "jdbc:mysql://0.0.0.0.0:3306/SimpleDB";
+        String wrongURL = "jdbc:mysql://0.0.0.0:3306abc/SimpleDB";
 
         //stream definition with invalid operation.
         String inStreamDefinition = "" +


### PR DESCRIPTION
## Purpose
In the current implementation, the JDBC URLs accept only IP addresses, but not the hostnames. This PR fixes it to accept any valid hostname in the JDBC URL.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes