### PR TITLE
Update README.md to reference only to setup mysql server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In addition to that, there are some prerequisites that need to be met based on t
 Currently MySQL, PostgreSQL and SQLServer are supported in Listening Mode.
 To capture the change events, databases have to be configured as shown below.
 
-* MySQL - https://debezium.io/docs/connectors/mysql/#setting-up-mysql
+* MySQL - https://debezium.io/documentation/reference/1.0/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.html
 * PostgreSQL - https://debezium.io/docs/connectors/postgresql/#setting-up-PostgreSQL
 * SQLServer - https://debezium.io/docs/connectors/sqlserver/#setting-up-sqlserver
 


### PR DESCRIPTION
## Purpose
> $subject, in the current README file, the link to setup MySQL is also reference to setup and run Kafka.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes