### PR TITLE
Bump DBZ version and fix connector properties

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -410,6 +410,8 @@ public class CDCSource extends Source<CDCSource.CdcState> {
         mode = optionHolder.validateAndGetStaticValue(CDCSourceConstants.MODE, CDCSourceConstants.MODE_LISTENING);
         //initialize common mandatory parameters
         String tableName = optionHolder.validateAndGetOption(CDCSourceConstants.TABLE_NAME).getValue();
+        String pluginName = optionHolder.validateAndGetStaticValue(CDCSourceConstants.PLUGIN_NAME,
+                CDCSourceConstants.DECORDERBUFS_PLUGIN);
         siddhiAppName = siddhiAppContext.getName();
         this.siddhiAppContextExecutorService = siddhiAppContext.getExecutorService();
         boolean isPrometheusReporterRunning = false;
@@ -474,7 +476,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
                 try {
                     Map<String, Object> configMap = CDCSourceUtil.getConfigMap(username, password, url, tableName,
                             historyFileDirectory, siddhiAppName, streamName, serverID, serverName, connectorProperties,
-                            this.hashCode(), (ListeningMetrics) metrics);
+                            this.hashCode(), (ListeningMetrics) metrics, pluginName);
                     changeDataCapture.setConfig(configMap);
                 } catch (WrongConfigurationException ex) {
                     throw new SiddhiAppCreationException("The cdc source couldn't get started because of invalid" +

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -41,6 +41,8 @@ public class CDCSourceConstants {
     public static final String CONNECTOR_CLASS = "connector.class";
     public static final String DATABASE_PORT = "database.port";
     public static final String TABLE_WHITELIST = "table.whitelist";
+    public static final String PLUGIN_NAME = "plugin.name";
+    public static final String DECORDERBUFS_PLUGIN = "decoderbufs";
     public static final String DATABASE_DBNAME = "database.dbname";
     public static final String DATABASE_HOSTNAME = "database.hostname";
     public static final String DATABASE_USER = "database.user";

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -37,7 +37,7 @@ public class CDCSourceUtil {
                                                    String historyFileDirectory, String siddhiAppName,
                                                    String siddhiStreamName, int serverID, String serverName,
                                                    String connectorProperties, int cdcSourceHashCode,
-                                                   ListeningMetrics metrics)
+                                                   ListeningMetrics metrics, String pluginName)
             throws WrongConfigurationException {
         Map<String, Object> configMap = new HashMap<>();
         String host;
@@ -99,6 +99,7 @@ public class CDCSourceUtil {
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
                     configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
                     configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+                    configMap.put(CDCSourceConstants.PLUGIN_NAME, pluginName);
 
                     //Add other PostgreSQL specific details to configMap.
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.POSTGRESQL_CONNECTOR_CLASS);

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -45,6 +45,8 @@ public class CDCSourceUtil {
         String database;
         Boolean isMongodb = false;
 
+        Map<String, String> connectorPropertiesMap = getConnectorPropertiesMap(connectorProperties);
+
         //Add schema specific details to configMap
         String[] splittedURL = url.split(":");
         if (!splittedURL[0].equalsIgnoreCase("jdbc")) {
@@ -149,8 +151,6 @@ public class CDCSourceUtil {
                                 siddhiStreamName + ". Expected url format: jdbc:oracle:<driver>://<host>:<port>/<sid>");
                     }
 
-                    Map<String, String> connectorPropertiesMap = getConnectorPropertiesMap(connectorProperties);
-
                     // Validate required connector properties
                     if (!connectorPropertiesMap.containsKey(CDCSourceConstants.ORACLE_OUTSERVER_PROPERTY_NAME)) {
                         throw new WrongConfigurationException("Required properties " +
@@ -158,11 +158,6 @@ public class CDCSourceUtil {
                                 CDCSourceConstants.CONNECTOR_PROPERTIES + " configurations.");
                     }
 
-                    String pdbName = connectorPropertiesMap.get(CDCSourceConstants.ORACLE_PDB_PROPERTY_NAME);
-
-                    if (pdbName != null) {
-                        configMap.put(CDCSourceConstants.ORACLE_PDB_PROPERTY_NAME, pdbName);
-                    }
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
                     configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
@@ -252,7 +247,7 @@ public class CDCSourceUtil {
             configMap.put(CDCSourceConstants.CONNECTOR_NAME, siddhiAppName + siddhiStreamName);
 
             //set additional connector properties using comma separated key value pair string
-            for (Map.Entry<String, String> entry : getConnectorPropertiesMap(connectorProperties).entrySet()) {
+            for (Map.Entry<String, String> entry : connectorPropertiesMap.entrySet()) {
                 configMap.put(entry.getKey(), entry.getValue());
             }
             return configMap;

--- a/pom.xml
+++ b/pom.xml
@@ -245,12 +245,12 @@
         <siddhi-map-keyvalue.version>2.0.7</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>0.10.0.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>0.10.0.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>0.10.0.Final</debezium-connector-oracle.version>
-        <debezium-connector-postgres.version>0.10.0.Final</debezium-connector-postgres.version>
-        <debezium-connector-sqlserver.version>0.10.0.Final</debezium-connector-sqlserver.version>
-        <debezium-connector-mongodb.version>0.10.0.Final</debezium-connector-mongodb.version>
+        <debezium-connector-mysql.version>1.2.1.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>1.2.1.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>1.2.1.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>1.2.1.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>1.2.1.Final</debezium-connector-sqlserver.version>
+        <debezium-connector-mongodb.version>1.2.1.Final</debezium-connector-mongodb.version>
         <version.oracle.driver>12.1.0.2</version.oracle.driver>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>


### PR DESCRIPTION
## Purpose
This PR bumps the Debezium client version to 1.2.1.Final and fix the connector properties parameter.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes