### PR TITLE
Close statements

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/DefaultPollingStrategy.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/DefaultPollingStrategy.java
@@ -107,7 +107,7 @@ public class DefaultPollingStrategy extends PollingStrategy {
 
     public String getLastReadPollingColumnValue(Connection connection) {
         String selectQuery;
-        PreparedStatement statement;
+        PreparedStatement statement = null;
         ResultSet resultSet = null;
         try {
             if (lastReadPollingColumnValue == null) {
@@ -126,7 +126,7 @@ public class DefaultPollingStrategy extends PollingStrategy {
         } catch (SQLException ex) {
             throw new CDCPollingModeException(buildError("Error in polling for changes on %s.", tableName), ex);
         } finally {
-            CDCPollingUtil.cleanupConnection(resultSet, null, null);
+            CDCPollingUtil.cleanupConnection(resultSet, statement, null);
         }
     }
 
@@ -135,7 +135,7 @@ public class DefaultPollingStrategy extends PollingStrategy {
         ResultSetMetaData metadata;
         Map<String, Object> detailsMap;
         String selectQuery;
-        PreparedStatement statement;
+        PreparedStatement statement = null;
         boolean isError = false;
         try {
             selectQuery = getSelectQuery("*", "WHERE " + pollingColumn + " > ?");
@@ -161,7 +161,7 @@ public class DefaultPollingStrategy extends PollingStrategy {
             }
             log.error(buildError("Error occurred while processing records in table %s.", tableName), ex);
         } finally {
-            CDCPollingUtil.cleanupConnection(resultSet, null, null);
+            CDCPollingUtil.cleanupConnection(resultSet, statement, null);
             return isError;
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/WaitOnMissingRecordPollingStrategy.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/WaitOnMissingRecordPollingStrategy.java
@@ -157,7 +157,7 @@ public class WaitOnMissingRecordPollingStrategy extends PollingStrategy {
                     }
                     log.error(buildError("Error occurred while processing records in table %s.", tableName), e);
                 } finally {
-                    CDCPollingUtil.cleanupConnection(resultSet, null, null);
+                    CDCPollingUtil.cleanupConnection(resultSet, statement, null);
                 }
                 try {
                     if (metrics != null) {


### PR DESCRIPTION
## Purpose
As we are using connection pool and not really closing the connection, if we don't close the statement we will exceed the open cursor limit.

## Goals
Close statement with resultset.

## Approach
Passing the statement to cleanup method.

## User stories

## Release note

## Documentation
This is an internal change, no need to change the documentation.

## Training

## Certification
N/A

## Marketing

## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning