### PR TITLE
Add support to capture multiple operations from single cdc source

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -674,7 +674,9 @@ public class CDCSource extends Source<CDCSource.CdcState> {
             }
             cdcPoller.stop();
         } else if (mode.equals(CDCSourceConstants.MODE_LISTENING)) {
-            engine.stop();
+            if (engine != null) {
+                engine.stop();
+            }
         }
     }
 

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -97,18 +97,19 @@ import static org.quartz.CronExpression.isValidExpression;
                 "In order to connect in to the database table for receive CDC events, url, username, password and " +
                 "driverClassName(in polling mode) can be provided in deployment.yaml file under the siddhi namespace " +
                 "as below, " +
-                "siddhi:\n" +
-                "  extensions:\n" +
-                "    -\n" +
-                "      extension:\n" +
-                "        name: 'cdc'\n" +
-                "        namespace: 'source'\n" +
-                "        properties:\n" +
-                "          url: jdbc:sqlserver://localhost:1433;databaseName=CDC_DATA_STORE\n" +
-                "          password: <password>\n" +
-                "          username: <>\n" +
-                "          driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver " +
-
+                " ```\n" +
+                "  siddhi:\n" +
+                "    extensions:\n" +
+                "      -\n" +
+                "        extension:\n" +
+                "          name: 'cdc'\n" +
+                "          namespace: 'source'\n" +
+                "          properties:\n" +
+                "            url: jdbc:sqlserver://localhost:1433;databaseName=CDC_DATA_STORE\n" +
+                "            password: <password>\n" +
+                "            username: <>\n" +
+                "            driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver " +
+                " ```\n"+
                 "#### Preparations required for working with Oracle Databases in listening mode\n" +
                 "\n" +
                 "Using the extension in Windows, Mac OSX and AIX are pretty straight forward inorder to achieve the " +
@@ -133,7 +134,17 @@ import static org.quartz.CronExpression.isValidExpression;
                 "  once ojdbc and xstreams jars are converted to OSGi copy the generated jars to the " +
                 "`<distribution>/lib`. Currently siddhi-io-cdc only supports the oracle database distributions " +
                 "12 and above" +
-
+                "\n" +
+                "#### Configurations for PostgreSQL\n" +
+                "When using listening mode with PostgreSQL, following properties has to be configured accordingly to " +
+                "create the connection." +
+                "\n" +
+                "slot.name: (default value = debezium) in postgreSQL only one connection can be created from " +
+                "           single slot, so to create multiple connection custom slot.name should be provided. " +
+                "plugin.name: (default value = decoderbufs ) Logical decoding output plugin name which the database " +
+                "is configured with. Other supported values are pgoutput, decoderbufs, wal2json." +
+                "table.name: table name should be provided as <schema_name>.<table_name>. As an example," +
+                " public.customer " +
                 "\n\nSee parameter: mode for supported databases and change events.",
         parameters = {
                 @Parameter(name = CDCSourceConstants.DATABASE_CONNECTION_URL,

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -109,7 +109,7 @@ import static org.quartz.CronExpression.isValidExpression;
                 "            password: <password>\n" +
                 "            username: <>\n" +
                 "            driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver " +
-                " ```\n"+
+                " ```\n" +
                 "#### Preparations required for working with Oracle Databases in listening mode\n" +
                 "\n" +
                 "Using the extension in Windows, Mac OSX and AIX are pretty straight forward inorder to achieve the " +

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -239,7 +239,12 @@ import static org.quartz.CronExpression.isValidExpression;
                 @Parameter(
                         name = CDCSourceConstants.OPERATION,
                         description = "The change event operation you want to carry out. Possible values are" +
-                                " 'insert', 'update' or 'delete'. This parameter is not case sensitive. " +
+                                " 'insert', 'update', 'delete' or now you can provide multiple operation as coma " +
+                                "separated values. This parameter is not case sensitive.  \n " +
+                                "When provided the multiple operations, the relevant operation for each event will " +
+                                "be return as a transport property **trp:operation** this can be access when mapping " +
+                                "the events. According to the operation, the required fields from the stream has to" +
+                                " be extracted. \n" +
                                 "**It is required to specify a value only when the mode is 'listening'.**\n",
                         type = DataType.STRING
                 ),

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -139,12 +139,12 @@ import static org.quartz.CronExpression.isValidExpression;
                 "When using listening mode with PostgreSQL, following properties has to be configured accordingly to " +
                 "create the connection." +
                 "\n" +
-                "slot.name: (default value = debezium) in postgreSQL only one connection can be created from " +
-                "           single slot, so to create multiple connection custom slot.name should be provided. " +
-                "plugin.name: (default value = decoderbufs ) Logical decoding output plugin name which the database " +
-                "is configured with. Other supported values are pgoutput, decoderbufs, wal2json." +
-                "table.name: table name should be provided as <schema_name>.<table_name>. As an example," +
-                " public.customer " +
+                "***slot.name***: (default value = debezium) in postgreSQL only one connection can be created from " +
+                "           single slot, so to create multiple connection custom slot.name should be provided.\n " +
+                "***plugin.name***: (default value = decoderbufs ) Logical decoding output plugin name which the " +
+                "database is configured with. Other supported values are pgoutput, decoderbufs, wal2json.\n" +
+                "***table.name***: table name should be provided as <schema_name>.<table_name>. As an example," +
+                " public.customer \n" +
                 "\n\nSee parameter: mode for supported databases and change events.",
         parameters = {
                 @Parameter(name = CDCSourceConstants.DATABASE_CONNECTION_URL,
@@ -429,6 +429,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
     private Metrics metrics;
     private String siddhiAppName;
     private ExecutorService siddhiAppContextExecutorService;
+    private boolean multipleOperationEnable = false;
 
     @Override
     protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
@@ -753,7 +754,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
                     " not be defined for listening mode");
         }
 
-        if (!(operation.equalsIgnoreCase(CDCSourceConstants.INSERT)
+        if (!operation.contains(",") && !(operation.equalsIgnoreCase(CDCSourceConstants.INSERT)
                 || operation.equalsIgnoreCase(CDCSourceConstants.UPDATE)
                 || operation.equalsIgnoreCase(CDCSourceConstants.DELETE))) {
             throw new SiddhiAppValidationException("Unsupported operation: '" + operation + "'." +

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -434,7 +434,6 @@ public class CDCSource extends Source<CDCSource.CdcState> {
     private Metrics metrics;
     private String siddhiAppName;
     private ExecutorService siddhiAppContextExecutorService;
-    private boolean multipleOperationEnable = false;
 
     @Override
     protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -94,6 +94,21 @@ import static org.quartz.CronExpression.isValidExpression;
                 "'before_'. e.g., specifying 'before_X' results in the key being added before the column named 'X'." +
                 "\n\nFor 'polling' mode: Keys are specified as the columns of the table." +
 
+                "In order to connect in to the database table for receive CDC events, url, username, password and " +
+                "driverClassName(in polling mode) can be provided in deployment.yaml file under the siddhi namespace " +
+                "as below, " +
+                "siddhi:\n" +
+                "  extensions:\n" +
+                "    -\n" +
+                "      extension:\n" +
+                "        name: 'cdc'\n" +
+                "        namespace: 'source'\n" +
+                "        properties:\n" +
+                "          url: jdbc:sqlserver://localhost:1433;databaseName=CDC_DATA_STORE\n" +
+                "          password: <password>\n" +
+                "          username: <>\n" +
+                "          driverClassName: com.microsoft.sqlserver.jdbc.SQLServerDriver " +
+
                 "#### Preparations required for working with Oracle Databases in listening mode\n" +
                 "\n" +
                 "Using the extension in Windows, Mac OSX and AIX are pretty straight forward inorder to achieve the " +
@@ -174,7 +189,7 @@ import static org.quartz.CronExpression.isValidExpression;
                         description = "Name of the wso2 datasource to connect to the database." +
                                 " When datasource name is provided, the URL, username and password are not needed. " +
                                 "A datasource based connection is given more priority over the URL based connection." +
-                                "\n This parameter is applicable only when the mode is set to 'polling', and it can" +
+                                "\n This parameter is applicable only when the mode is set to **polling**, and it can" +
                                 " be applied only when you use this extension with WSO2 Stream Processor.",
                         type = DataType.STRING,
                         defaultValue = "<Empty_String>",

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -239,7 +239,7 @@ import static org.quartz.CronExpression.isValidExpression;
                 @Parameter(
                         name = CDCSourceConstants.OPERATION,
                         description = "The change event operation you want to carry out. Possible values are" +
-                                " 'insert', 'update', 'delete' or now you can provide multiple operation as coma " +
+                                " 'insert', 'update', 'delete' or you can provide multiple operation as coma " +
                                 "separated values. This parameter is not case sensitive.  \n " +
                                 "When provided the multiple operations, the relevant operation for each event will " +
                                 "be return as a transport property **trp:operation** this can be access when mapping " +
@@ -350,6 +350,19 @@ import static org.quartz.CronExpression.isValidExpression;
                         syntax = "@source(type = 'cdc' , url = 'jdbc:mysql://localhost:3306/SimpleDB', " +
                                 "\nusername = 'cdcuser', password = 'pswd4cdc', " +
                                 "\ntable.name = 'students', operation = 'delete', " +
+                                "\n@map(type='keyvalue', @attributes(before_id = 'before_id'," +
+                                " before_name = 'before_name', name = 'name', id = 'id'," +
+                                " operation= 'trp:operation')))" +
+                                "\ndefine stream inputStream (id string, name string, before_id string," +
+                                " before_name string, operation string);",
+                        description = "In this example, the CDC source listens to the row deletions made in the " +
+                                "'students' table. This table belongs to the 'SimpleDB' database that can be accessed" +
+                                " via the given URL."
+                ),
+                @Example(
+                        syntax = "@source(type = 'cdc' , url = 'jdbc:mysql://localhost:3306/SimpleDB', " +
+                                "\nusername = 'cdcuser', password = 'pswd4cdc', " +
+                                "\ntable.name = 'students', operation = 'insert,update,delete', " +
                                 "\n@map(type='keyvalue', @attributes(before_id = 'before_id'," +
                                 " before_name = 'before_name')))" +
                                 "\ndefine stream inputStream (before_id string, before_name string);",

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -351,10 +351,8 @@ import static org.quartz.CronExpression.isValidExpression;
                                 "\nusername = 'cdcuser', password = 'pswd4cdc', " +
                                 "\ntable.name = 'students', operation = 'delete', " +
                                 "\n@map(type='keyvalue', @attributes(before_id = 'before_id'," +
-                                " before_name = 'before_name', name = 'name', id = 'id'," +
-                                " operation= 'trp:operation')))" +
-                                "\ndefine stream inputStream (id string, name string, before_id string," +
-                                " before_name string, operation string);",
+                                " before_name = 'before_name')))" +
+                                "\ndefine stream inputStream (before_id string, before_name string);",
                         description = "In this example, the CDC source listens to the row deletions made in the " +
                                 "'students' table. This table belongs to the 'SimpleDB' database that can be accessed" +
                                 " via the given URL."
@@ -364,9 +362,11 @@ import static org.quartz.CronExpression.isValidExpression;
                                 "\nusername = 'cdcuser', password = 'pswd4cdc', " +
                                 "\ntable.name = 'students', operation = 'insert,update,delete', " +
                                 "\n@map(type='keyvalue', @attributes(before_id = 'before_id'," +
-                                " before_name = 'before_name')))" +
-                                "\ndefine stream inputStream (before_id string, before_name string);",
-                        description = "In this example, the CDC source listens to the row deletions made in the " +
+                                " before_name = 'before_name', name = 'name', id = 'id'," +
+                                " operation= 'trp:operation')))" +
+                                "\ndefine stream inputStream (id string, name string, before_id string," +
+                                " before_name string, operation string);",
+                        description = "In this example, the CDC source listens to multiple operations of the " +
                                 "'students' table. This table belongs to the 'SimpleDB' database that can be accessed" +
                                 " via the given URL."
                 ),

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
@@ -28,8 +28,10 @@ import org.apache.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,6 +47,7 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
     Map<String, Object> createMap(ConnectRecord connectRecord, String operation) {
         //Map to return
         Map<String, Object> detailsMap = new HashMap<>();
+        List<Object> transportProperties = new ArrayList();
         Struct record = (Struct) connectRecord.value();
         //get the change data object's operation.
         String op;
@@ -62,12 +65,16 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
                 op.equals(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION)) {
             switch (op) {
                 case CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION:
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
+                            transportProperties.add(CDCSourceConstants.INSERT));
                     //append row details after insert.
                     String insertString = (String) record.get(CDCSourceConstants.AFTER);
                     JSONObject jsonObj = new JSONObject(insertString);
                     detailsMap = getMongoDetailMap(jsonObj);
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION:
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
+                            transportProperties.add(CDCSourceConstants.DELETE));
                     //append row details before delete.
                     String deleteDocumentId = (String) ((Struct) connectRecord.key())
                             .get(CDCSourceConstants.MONGO_COLLECTION_ID);
@@ -77,6 +84,8 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
 
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION:
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
+                            transportProperties.add(CDCSourceConstants.UPDATE));
                     //append row details before update.
                     String updateDocument = (String) record.get(CDCSourceConstants.MONGO_PATCH);
                     JSONObject jsonObj1 = new JSONObject(updateDocument);

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
@@ -68,6 +68,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                 case CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION:
                     if (operationList.contains(CDCSourceConstants.INSERT)) {
                         transportProperties.add(CDCSourceConstants.INSERT);
+                        detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                         rawDetails = (Struct) record.get(CDCSourceConstants.AFTER);
                         fields = rawDetails.schema().fields();
                         for (Field key : fields) {
@@ -81,6 +82,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                 case CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION:
                     if (operationList.contains(CDCSourceConstants.UPDATE)) {
                         transportProperties.add(CDCSourceConstants.UPDATE);
+                        detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                         rawDetails = (Struct) record.get(CDCSourceConstants.BEFORE);
                         fields = rawDetails.schema().fields();
                         for (Field key : fields) {
@@ -101,6 +103,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                 case CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION:
                     if (operationList.contains(CDCSourceConstants.DELETE)) {
                         transportProperties.add(CDCSourceConstants.DELETE);
+                        detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                         rawDetails = (Struct) record.get(CDCSourceConstants.BEFORE);
                         fields = rawDetails.schema().fields();
                         for (Field key : fields) {
@@ -126,6 +129,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
             switch (op) {
                 case CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION:
                     transportProperties.add(CDCSourceConstants.INSERT);
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                     //append row details after insert.
                     rawDetails = (Struct) record.get(CDCSourceConstants.AFTER);
                     fields = rawDetails.schema().fields();
@@ -136,6 +140,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION:
                     transportProperties.add(CDCSourceConstants.DELETE);
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                     //append row details before delete.
                     rawDetails = (Struct) record.get(CDCSourceConstants.BEFORE);
                     fields = rawDetails.schema().fields();
@@ -147,6 +152,7 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION:
                     transportProperties.add(CDCSourceConstants.UPDATE);
+                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
                     //append row details before update.
                     rawDetails = (Struct) record.get(CDCSourceConstants.BEFORE);
                     fields = rawDetails.schema().fields();
@@ -168,7 +174,6 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
                     break;
             }
         }
-        detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
         return detailsMap;
     }
 

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -40,7 +40,7 @@ public class CDCSourceConstants {
     public static final String DELETE = "delete";
     public static final String CONNECTOR_CLASS = "connector.class";
     public static final String DATABASE_PORT = "database.port";
-    public static final String TABLE_WHITELIST = "table.whitelist";
+    public static final String TABLE_TABLE_INCLUDE_LIST = "table.include.list";
     public static final String PLUGIN_NAME = "plugin.name";
     public static final String DECORDERBUFS_PLUGIN = "decoderbufs";
     public static final String DATABASE_DBNAME = "database.dbname";
@@ -86,7 +86,7 @@ public class CDCSourceConstants {
     public static final String MONGODB_PASSWORD = "mongodb.password";
     public static final String MONGODB_HOSTS = "mongodb.hosts";
     public static final String MONGODB_NAME = "mongodb.name";
-    public static final String MONGODB_COLLECTION_WHITELIST = "collection.whitelist";
+    public static final String MONGODB_COLLECTION_INCLUDE_LIST = "collection.include.list";
     public static final String MONGO_COLLECTION_OBJECT_ID = "$oid";
     public static final String MONGO_COLLECTION_ID = "id";
     public static final String MONGO_COLLECTION_INSERT_ID = "_id";
@@ -102,4 +102,8 @@ public class CDCSourceConstants {
     public static final String TRIGGER_NAME = "CDCCronTriggerName";
     public static final String TRIGGER_GROUP = "CDCCronTriggerGroup";
     public static final String POLLING_STRATEGY = "PollingStrategy";
+
+    public static final String TRANSPORT_PROPERTIES = "transportProperties";
+    public static final String OPERATION_SEPARATOR = ",";
 }
+

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -71,7 +71,7 @@ public class CDCSourceUtil {
 
                     //Add extracted url details to configMap.
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
-                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, database + "." + tableName);
+                    configMap.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, database + "." + tableName);
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
 
                     //Add other MySQL specific details to configMap.
@@ -100,7 +100,7 @@ public class CDCSourceUtil {
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
                     configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
-                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+                    configMap.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, tableName);
                     configMap.put(CDCSourceConstants.PLUGIN_NAME, pluginName);
 
                     //Add other PostgreSQL specific details to configMap.
@@ -127,7 +127,7 @@ public class CDCSourceUtil {
                     //Add extracted url details to configMap.
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
-                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+                    configMap.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, tableName);
                     configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
 
                     //Add other SQLServer specific details to configMap.
@@ -160,7 +160,7 @@ public class CDCSourceUtil {
 
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
-                    configMap.put(CDCSourceConstants.TABLE_WHITELIST, tableName);
+                    configMap.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, tableName);
                     configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.ORACLE_CONNECTOR_CLASS);
                     if (metrics != null) {
@@ -192,7 +192,7 @@ public class CDCSourceUtil {
                     //unique name that identifies the connector and/or MongoDB replica set or sharded cluster
                     configMap.put(CDCSourceConstants.MONGODB_NAME, replicaSetName);
                     //fully-qualified namespaces for MongoDB collections to be monitored
-                    configMap.put(CDCSourceConstants.MONGODB_COLLECTION_WHITELIST, database + "." + tableName);
+                    configMap.put(CDCSourceConstants.MONGODB_COLLECTION_INCLUDE_LIST, database + "." + tableName);
                     if (metrics != null) {
                         metrics.setDbType("MongoDB");
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -245,12 +245,12 @@
         <siddhi-map-keyvalue.version>2.0.7</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>1.2.1.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>1.2.1.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>1.2.1.Final</debezium-connector-oracle.version>
-        <debezium-connector-postgres.version>1.2.1.Final</debezium-connector-postgres.version>
-        <debezium-connector-sqlserver.version>1.2.1.Final</debezium-connector-sqlserver.version>
-        <debezium-connector-mongodb.version>1.2.1.Final</debezium-connector-mongodb.version>
+        <debezium-connector-mysql.version>1.4.0.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>1.4.0.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>1.4.0.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>1.4.0.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>1.4.0.Final</debezium-connector-sqlserver.version>
+        <debezium-connector-mongodb.version>1.4.0.Final</debezium-connector-mongodb.version>
         <version.oracle.driver>12.1.0.2</version.oracle.driver>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>


### PR DESCRIPTION
## Purpose
* This PR will add support to capture multiple operations occurs in database through a single CDC source. the Siddhi event which generate in regards to the CDC event now consists with a transport property call operation, which will provide the operation which was captured from the database. 
* This PR also contains a version bump for Debezium connector from 1.2.1_final to 1.4.1_final.
* Improved CDC source to read configurations from deployment.yaml file
* Minor bug fix in cdc polling mode when using in SI tooling editor runtime where it tries to disconnect the cdc connection when the connection is not yet established. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
