### PR TITLE
Update Oracle URL regex to support @ character

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -138,7 +138,7 @@ public class CDCSourceUtil {
                     break;
                 }
                 case "oracle": {
-                    String regex = "jdbc:oracle:(\\w*):\\/\\/([a-zA-Z0-9-_\\.]+):(\\d+)([\\/]?)([a-zA-Z0-9-_\\.]*)";
+                    String regex = "jdbc:oracle:(\\w*):@?\\/?\\/?([a-zA-Z0-9-_\\.]+):(\\d+)([\\/]?)([a-zA-Z0-9-_\\.]*)";
                     Pattern p = Pattern.compile(regex);
                     Matcher matcher = p.matcher(url);
 


### PR DESCRIPTION
## Purpose
This PR updates the Oracle DB URL regex to support @ character.

Fixes https://github.com/wso2/api-manager/issues/2318