### PR TITLE
Upgrade Debezium 1.9 → 2.7, log4j 2.17 → 2.25, kafka-connect 2.3 → 3.7 (SI 4.4.0)

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -594,6 +594,10 @@
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <!-- Explicitly set EE requirement to Java 1.8 (compiler target).
+                             bnd 3.0.0 cannot parse Java 11 bytecode major version 55 from
+                             embedded Debezium 2.x jars, producing a null filter otherwise. -->
+                        <Require-Capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</Require-Capability>
                         <Include-Resource>
                             META-INF=target/classes/META-INF,
                             META-INF/services=${project.build.directory}/dependencies/connect-runtime/META-INF/services,

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.siddhi.extension.io.cdc</groupId>
         <artifactId>siddhi-io-cdc-parent</artifactId>
-        <version>2.0.18-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>siddhi-io-cdc</artifactId>

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -18,7 +18,7 @@
 
 package io.siddhi.extension.io.cdc.source;
 
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.engine.DebeziumEngine;
 import io.siddhi.annotation.Example;
 import io.siddhi.annotation.Extension;
 import io.siddhi.annotation.Parameter;
@@ -48,6 +48,7 @@ import io.siddhi.extension.io.cdc.source.polling.CDCPoller;
 import io.siddhi.extension.io.cdc.util.CDCSourceConstants;
 import io.siddhi.extension.io.cdc.util.CDCSourceUtil;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.JobKey;
@@ -444,7 +445,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
     private String cronExpression = null;
     private CronConfiguration cronConfiguration;
     private boolean waitOnMissedRecord;
-    private EmbeddedEngine engine;
+    private DebeziumEngine<SourceRecord> engine;
     private Metrics metrics;
     private String siddhiAppName;
     private ExecutorService siddhiAppContextExecutorService;
@@ -646,7 +647,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
                 cdcSourceObjectKeeper.addCdcObject(this);
 
                 //create completion callback to handle the exceptions from debezium engine.
-                EmbeddedEngine.CompletionCallback completionCallback = (success, message, error) -> {
+                DebeziumEngine.CompletionCallback completionCallback = (success, message, error) -> {
                     if (!success) {
                         connectionCallback.onError(new ConnectionUnavailableException(
                                 "Connection to the database lost.", error));
@@ -705,7 +706,11 @@ public class CDCSource extends Source<CDCSource.CdcState> {
             cdcPoller.stop();
         } else if (mode.equals(CDCSourceConstants.MODE_LISTENING)) {
             if (engine != null) {
-                engine.stop();
+                try {
+                    engine.close();
+                } catch (java.io.IOException e) {
+                    log.error("Error closing the CDC engine.", e);
+                }
             }
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -658,7 +658,17 @@ public class CDCSource extends Source<CDCSource.CdcState> {
                     }
                 };
                 engine = changeDataCapture.getEngine(completionCallback);
-                executorService.execute(engine);
+                final DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engineToRun = engine;
+                final ClassLoader bundleClassLoader = CDCSource.class.getClassLoader();
+                executorService.execute(() -> {
+                    ClassLoader originalCL = Thread.currentThread().getContextClassLoader();
+                    Thread.currentThread().setContextClassLoader(bundleClassLoader);
+                    try {
+                        engineToRun.run();
+                    } finally {
+                        Thread.currentThread().setContextClassLoader(originalCL);
+                    }
+                });
                 break;
             case CDCSourceConstants.MODE_POLLING:
                 //create a completion callback to handle exceptions from CDCPoller

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/CDCSource.java
@@ -18,6 +18,7 @@
 
 package io.siddhi.extension.io.cdc.source;
 
+import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.siddhi.annotation.Example;
 import io.siddhi.annotation.Extension;
@@ -445,7 +446,7 @@ public class CDCSource extends Source<CDCSource.CdcState> {
     private String cronExpression = null;
     private CronConfiguration cronConfiguration;
     private boolean waitOnMissedRecord;
-    private DebeziumEngine<SourceRecord> engine;
+    private DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine;
     private Metrics metrics;
     private String siddhiAppName;
     private ExecutorService siddhiAppContextExecutorService;

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
@@ -19,7 +19,8 @@
 package io.siddhi.extension.io.cdc.source.listening;
 
 import io.debezium.config.Configuration;
-import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.embedded.Connect;
+import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.spi.OffsetCommitPolicy;
 import io.siddhi.core.exception.SiddhiAppRuntimeException;
@@ -46,7 +47,7 @@ import static io.siddhi.extension.io.cdc.util.CDCSourceConstants.OPERATION_SEPAR
 public abstract class ChangeDataCapture {
     private final ListeningMetrics metrics;
     private String operation;
-    private Configuration config;
+    private Configuration config = Configuration.empty();
     private SourceEventListener sourceEventListener;
     private ReentrantLock lock = new ReentrantLock();
     private Condition condition = lock.newCondition();
@@ -76,16 +77,14 @@ public abstract class ChangeDataCapture {
      *
      * @return {@code engine}.
      */
-    @SuppressWarnings("unchecked")
-    public DebeziumEngine<SourceRecord> getEngine(DebeziumEngine.CompletionCallback completionCallback) {
+    public DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> getEngine(
+            DebeziumEngine.CompletionCallback completionCallback) {
         // Create and return Engine with above set configuration ...
-        DebeziumEngine.Builder<SourceRecord> builder = (DebeziumEngine.Builder<SourceRecord>)
-                new EmbeddedEngine.EngineBuilder()
-                        .using(OffsetCommitPolicy.always())
-                        .using(completionCallback)
-                        .using(config.asProperties());
-        DebeziumEngine<SourceRecord> engine = builder
-                .notifying((SourceRecord record) -> handleEvent(record))
+        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = DebeziumEngine.create(Connect.class)
+                .using(config.asProperties())
+                .using(OffsetCommitPolicy.always())
+                .using(completionCallback)
+                .notifying((ChangeEvent<SourceRecord, SourceRecord> event) -> handleEvent(event.value()))
                 .build();
         if (engine == null) {
             if (metrics != null) {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
@@ -20,7 +20,8 @@ package io.siddhi.extension.io.cdc.source.listening;
 
 import io.debezium.config.Configuration;
 import io.debezium.embedded.EmbeddedEngine;
-import io.debezium.embedded.spi.OffsetCommitPolicy;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.spi.OffsetCommitPolicy;
 import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.stream.input.source.SourceEventListener;
 import io.siddhi.core.stream.input.source.SourceMapper;
@@ -29,6 +30,7 @@ import io.siddhi.extension.io.cdc.source.metrics.ListeningMetrics;
 import io.siddhi.extension.io.cdc.util.CDCSourceConstants;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,21 +76,24 @@ public abstract class ChangeDataCapture {
      *
      * @return {@code engine}.
      */
-    public EmbeddedEngine getEngine(EmbeddedEngine.CompletionCallback completionCallback) {
+    @SuppressWarnings("unchecked")
+    public DebeziumEngine<SourceRecord> getEngine(DebeziumEngine.CompletionCallback completionCallback) {
         // Create and return Engine with above set configuration ...
-        EmbeddedEngine.Builder builder = EmbeddedEngine.create()
-                .using(OffsetCommitPolicy.always())
-                .using(completionCallback)
-                .using(config);
-        if (builder == null) {
+        DebeziumEngine.Builder<SourceRecord> builder = (DebeziumEngine.Builder<SourceRecord>)
+                new EmbeddedEngine.EngineBuilder()
+                        .using(OffsetCommitPolicy.always())
+                        .using(completionCallback)
+                        .using(config.asProperties());
+        DebeziumEngine<SourceRecord> engine = builder
+                .notifying((SourceRecord record) -> handleEvent(record))
+                .build();
+        if (engine == null) {
             if (metrics != null) {
                 metrics.setCDCStatus(CDCStatus.ERROR);
             }
             throw new SiddhiAppRuntimeException("CDC Engine create failed. Check parameters.");
-        } else {
-            EmbeddedEngine engine = builder.notifying(this::handleEvent).build();
-            return engine;
         }
+        return engine;
     }
 
     public void pause() {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/InMemoryOffsetBackingStore.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/InMemoryOffsetBackingStore.java
@@ -27,7 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class saves and loads the change data offsets in in-memory.
@@ -74,6 +76,11 @@ public class InMemoryOffsetBackingStore extends MemoryOffsetBackingStore {
     public void stop() {
         super.stop();
         log.debug("Stopped InMemoryOffsetBackingStore");
+    }
+
+    @Override
+    public Set<Map<String, Object>> connectorPartitions(String connectorName) {
+        return new HashSet<>();
     }
 
     /**

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
@@ -203,7 +203,11 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
             if (bigDecimal == null) {
                 return null;
             }
-            return bigDecimal.longValue();
+            BigDecimal normalized = bigDecimal.stripTrailingZeros();
+            if (normalized.scale() <= 0) {
+                return bigDecimal.longValue();
+            }
+            return bigDecimal.doubleValue();
         }
         if (v instanceof Short) {
             return ((Short) v).intValue();

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -27,9 +27,9 @@ public class CDCSourceConstants {
     public static final String DATABASE_CONNECTION_URL = "url";
     public static final String POOL_PROPERTIES = "pool.properties";
     public static final String OPERATION = "operation";
-    public static final String DATABASE_HISTORY_FILEBASE_HISTORY = "io.debezium.relational.history.FileDatabaseHistory";
-    public static final String DATABASE_HISTORY_FILE_NAME = "database.history.file.filename";
-    public static final String DATABASE_SERVER_NAME = "database.server.name";
+    public static final String DATABASE_HISTORY_FILEBASE_HISTORY = "io.debezium.storage.file.history.FileSchemaHistory";
+    public static final String DATABASE_HISTORY_FILE_NAME = "schema.history.internal.file.filename";
+    public static final String DATABASE_SERVER_NAME = "topic.prefix";
     public static final String DATABASE_SERVER_ID = "database.server.id";
     public static final String SERVER_ID = "server.id";
     public static final String TABLE_NAME = "table.name";
@@ -49,7 +49,7 @@ public class CDCSourceConstants {
     public static final String DATABASE_PASSWORD = "database.password";
     public static final String OFFSET_STORAGE = "offset.storage";
     public static final String CDC_SOURCE_OBJECT = "cdc.source.object";
-    public static final String DATABASE_HISTORY = "database.history";
+    public static final String DATABASE_HISTORY = "schema.history.internal";
     public static final String MYSQL_CONNECTOR_CLASS = "io.debezium.connector.mysql.MySqlConnector";
     public static final String POSTGRESQL_CONNECTOR_CLASS = "io.debezium.connector.postgresql.PostgresConnector";
     public static final String ORACLE_CONNECTOR_CLASS = "io.debezium.connector.oracle.OracleConnector";
@@ -86,6 +86,8 @@ public class CDCSourceConstants {
     public static final String MONGODB_PASSWORD = "mongodb.password";
     public static final String MONGODB_HOSTS = "mongodb.hosts";
     public static final String MONGODB_NAME = "mongodb.name";
+    public static final String MONGODB_CONNECTION_STRING = "mongodb.connection.string";
+    public static final String SQLSERVER_DATABASE_NAMES = "database.names";
     public static final String MONGODB_COLLECTION_INCLUDE_LIST = "collection.include.list";
     public static final String MONGO_COLLECTION_OBJECT_ID = "$oid";
     public static final String MONGO_COLLECTION_ID = "id";

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -227,9 +227,9 @@ public class CDCSourceUtil {
 
             if (serverID == CDCSourceConstants.DEFAULT_SERVER_ID) {
                 SecureRandom random = new SecureRandom();
-                configMap.put(CDCSourceConstants.SERVER_ID, random.nextInt(1001) + 5400);
+                configMap.put(CDCSourceConstants.DATABASE_SERVER_ID, random.nextInt(1001) + 5400);
             } else {
-                configMap.put(CDCSourceConstants.SERVER_ID, serverID);
+                configMap.put(CDCSourceConstants.DATABASE_SERVER_ID, serverID);
             }
 
             //set the database server name if specified, otherwise set <host>_<port> as default

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -128,7 +128,7 @@ public class CDCSourceUtil {
                     configMap.put(CDCSourceConstants.DATABASE_HOSTNAME, host);
                     configMap.put(CDCSourceConstants.DATABASE_PORT, port);
                     configMap.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, tableName);
-                    configMap.put(CDCSourceConstants.DATABASE_DBNAME, database);
+                    configMap.put(CDCSourceConstants.SQLSERVER_DATABASE_NAMES, database);
 
                     //Add other SQLServer specific details to configMap.
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS);
@@ -187,10 +187,14 @@ public class CDCSourceUtil {
                                 "<database_name>");
                     }
                     configMap.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.MONGODB_CONNECTOR_CLASS);
-                    //hostname and port pairs of the MongoDB servers in the replica set.
-                    configMap.put(CDCSourceConstants.MONGODB_HOSTS, host + ":" + port);
-                    //unique name that identifies the connector and/or MongoDB replica set or sharded cluster
-                    configMap.put(CDCSourceConstants.MONGODB_NAME, replicaSetName);
+                    String actualHost = (replicaSetName != null && !replicaSetName.isEmpty())
+                            ? host.substring(host.indexOf('/') + 1)
+                            : host;
+                    String connectionString = "mongodb://" + actualHost + ":" + port + "/";
+                    if (replicaSetName != null && !replicaSetName.isEmpty()) {
+                        connectionString += "?replicaSet=" + replicaSetName;
+                    }
+                    configMap.put(CDCSourceConstants.MONGODB_CONNECTION_STRING, connectionString);
                     //fully-qualified namespaces for MongoDB collections to be monitored
                     configMap.put(CDCSourceConstants.MONGODB_COLLECTION_INCLUDE_LIST, database + "." + tableName);
                     if (metrics != null) {

--- a/component/src/main/resources/META-INF/services/io.debezium.converters.spi.CloudEventsProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.converters.spi.CloudEventsProvider
@@ -1,0 +1,5 @@
+io.debezium.connector.postgresql.converters.PostgresCloudEventsProvider
+io.debezium.connector.mysql.converters.MySqlCloudEventsProvider
+io.debezium.connector.sqlserver.converters.SqlServerCloudEventsProvider
+io.debezium.connector.oracle.converters.OracleCloudEventsProvider
+io.debezium.connector.mongodb.converters.MongoDbCloudEventsProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$BuilderFactory
+++ b/component/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$BuilderFactory
@@ -1,0 +1,2 @@
+io.debezium.embedded.ConvertingEngineBuilderFactory
+io.debezium.embedded.async.ConvertingAsyncEngineBuilderFactory

--- a/component/src/main/resources/META-INF/services/io.debezium.metadata.ConnectorMetadataProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.metadata.ConnectorMetadataProvider
@@ -1,0 +1,5 @@
+io.debezium.connector.postgresql.metadata.PostgresConnectorMetadataProvider
+io.debezium.connector.mysql.metadata.MySqlConnectorMetadataProvider
+io.debezium.connector.sqlserver.metadata.SqlServerConnectorMetadataProvider
+io.debezium.connector.oracle.metadata.OracleConnectorMetadataProvider
+io.debezium.connector.mongodb.metadata.MongoDbConnectorMetadataProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
+++ b/component/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
@@ -1,0 +1,3 @@
+io.debezium.pipeline.notification.channels.SinkNotificationChannel
+io.debezium.pipeline.notification.channels.LogNotificationChannel
+io.debezium.pipeline.notification.channels.jmx.JmxNotificationChannel

--- a/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.actions.SignalActionProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.actions.SignalActionProvider
@@ -1,0 +1,1 @@
+io.debezium.pipeline.signal.actions.StandardActionProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.channels.SignalChannelReader
+++ b/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.channels.SignalChannelReader
@@ -1,0 +1,4 @@
+io.debezium.pipeline.signal.channels.SourceSignalChannel
+io.debezium.pipeline.signal.channels.KafkaSignalChannel
+io.debezium.pipeline.signal.channels.FileSignalChannel
+io.debezium.pipeline.signal.channels.jmx.JmxSignalChannel

--- a/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
+++ b/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
@@ -1,0 +1,11 @@
+io.debezium.snapshot.lock.NoLockingSupport
+io.debezium.connector.postgresql.snapshot.lock.NoSnapshotLock
+io.debezium.connector.postgresql.snapshot.lock.SharedSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.ExtendedSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalPerconaSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.NoneSnapshotLock
+io.debezium.connector.sqlserver.snapshot.lock.NoSnapshotLock
+io.debezium.connector.sqlserver.snapshot.lock.ExclusiveSnapshotLock
+io.debezium.connector.oracle.snapshot.lock.NoSnapshotLock
+io.debezium.connector.oracle.snapshot.lock.SharedSnapshotLock

--- a/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
+++ b/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
@@ -1,0 +1,4 @@
+io.debezium.connector.postgresql.snapshot.query.SelectAllSnapshotQuery
+io.debezium.connector.mysql.snapshot.query.SelectAllSnapshotQuery
+io.debezium.connector.sqlserver.snapshot.query.SelectAllSnapshotQuery
+io.debezium.connector.oracle.snapshot.query.SelectAllSnapshotQuery

--- a/component/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/component/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -1,0 +1,10 @@
+io.debezium.snapshot.mode.AlwaysSnapshotter
+io.debezium.snapshot.mode.InitialSnapshotter
+io.debezium.snapshot.mode.InitialOnlySnapshotter
+io.debezium.snapshot.mode.NoDataSnapshotter
+io.debezium.snapshot.mode.RecoverySnapshotter
+io.debezium.snapshot.mode.WhenNeededSnapshotter
+io.debezium.snapshot.mode.NeverSnapshotter
+io.debezium.snapshot.mode.SchemaOnlySnapshotter
+io.debezium.snapshot.mode.SchemaOnlyRecoverySnapshotter
+io.debezium.snapshot.mode.ConfigurationBasedSnapshotter

--- a/component/src/main/resources/META-INF/services/io.debezium.transforms.outbox.EventRouterConfigurationProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.transforms.outbox.EventRouterConfigurationProvider
@@ -1,0 +1,1 @@
+io.debezium.connector.oracle.transforms.outbox.OracleEventRouterConfigurationProvider

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </modules>
     <groupId>io.siddhi.extension.io.cdc</groupId>
     <artifactId>siddhi-io-cdc-parent</artifactId>
-    <version>2.0.18-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>Siddhi I/O cdc</name>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@
                 <version>${org.snake.yaml.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.analytics</groupId>
                 <artifactId>org.wso2.carbon.si.metrics.core</artifactId>
                 <version>${carbon.analytics.version}</version>
@@ -305,19 +310,19 @@
         </plugins>
     </build>
     <properties>
-        <siddhi.version>5.1.21</siddhi.version>
+        <siddhi.version>5.1.32</siddhi.version>
         <siddhi.import.version.range>[5.1.0,6.0.0)</siddhi.import.version.range>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <carbon.transport.version>4.4.15</carbon.transport.version>
         <siddhi-map-keyvalue.version>2.1.2</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>1.9.7.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>1.9.7.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>1.9.7.Final</debezium-connector-oracle.version>
-        <debezium-connector-postgres.version>1.9.7.Final</debezium-connector-postgres.version>
-        <debezium-connector-sqlserver.version>1.9.7.Final</debezium-connector-sqlserver.version>
-        <debezium-connector-mongodb.version>1.9.7.Final</debezium-connector-mongodb.version>
+        <debezium-connector-mysql.version>2.7.3.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>2.7.3.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>2.7.3.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>2.7.3.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>2.7.3.Final</debezium-connector-sqlserver.version>
+        <debezium-connector-mongodb.version>2.7.3.Final</debezium-connector-mongodb.version>
         <version.oracle.driver>12.1.0.2</version.oracle.driver>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>
@@ -338,13 +343,14 @@
         <siddhi-cdc-postgres.port>5433</siddhi-cdc-postgres.port>
         <docker.container.siddhi-cdc-postgres.ip>0.0.0.0</docker.container.siddhi-cdc-postgres.ip>
         <oracle.jdbc.Driver.version>12.2.0.1</oracle.jdbc.Driver.version>
-        <kafka.connect.version>2.3.0</kafka.connect.version>
+        <kafka.connect.version>3.7.1</kafka.connect.version>
         <mongodb.connector.version>3.4.0</mongodb.connector.version>
         <json.version>20190722</json.version>
         <carbon.analytics.version>3.0.57</carbon.analytics.version>
         <org.yaml.snakeyaml.version.range>[2.0.0,3.0.0)</org.yaml.snakeyaml.version.range>
         <com.zaxxer.hikari.version.range>[1.0.0,4.0.0)</com.zaxxer.hikari.version.range>
         <org.snake.yaml.version>2.2</org.snake.yaml.version>
+        <protobuf.version>3.25.5</protobuf.version>
     </properties>
     <scm>
         <url>https://github.com/siddhi-io/siddhi-io-cdc.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
         <log4j.version>2.25.4</log4j.version>
         <carbon.transport.version>4.4.15</carbon.transport.version>
         <siddhi-map-keyvalue.version>2.1.2</siddhi-map-keyvalue.version>
-        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
         <debezium-connector-mysql.version>2.7.3.Final</debezium-connector-mysql.version>
         <debezium-embedded.version>2.7.3.Final</debezium-embedded.version>


### PR DESCRIPTION
## Summary

- `debezium` 1.9.7.Final → 2.7.3.Final — CVEs + 1.x EOL
- `log4j` 2.17.1 → 2.25.4 — CVE-2021-44832, CVE-2021-45046, CVE-2021-45105
- `kafka-connect` 2.3.0 → 3.7.1 — required by Debezium 2.x
- `siddhi` 5.1.21 → 5.1.32 — required for log4j ≥ 2.19 compatibility
- Version bump: 2.0.18 → 2.1.0 (see breaking changes below)

## Debezium 2.x migration

- API: `EmbeddedEngine` → `DebeziumEngine`, `engine.stop()` → `engine.close()`, `OffsetCommitPolicy` package relocated
- Config properties renamed: `database.server.name` → `topic.prefix`, `database.history` → `schema.history.internal`, `FileDatabaseHistory` → `FileSchemaHistory`
- MongoDB: `mongodb.hosts` + `mongodb.name` → `mongodb.connection.string`
- SQLServer: `database.dbname` → `database.names`
- OSGi: embed all 10 Debezium `META-INF/services/` files; set TCCL to bundle classloader before running engine (Debezium uses TCCL-dependent `ServiceLoader.load`)
- Bug fix: PostgreSQL `numeric` columns with decimal values now map correctly to `double` (previously truncated to `Long`)

## Breaking changes

Existing CDC offset files are keyed by `database.server.name`. After upgrade the key becomes `topic.prefix` with a different value — **CDC will restart from scratch** and re-emit all rows.

## Test plan

- [x] 15/15 H2 polling-mode tests pass (`testng-suit1.xml`)
- [x] JAR builds and all 10 Debezium service files present in bundle
- [x] PostgreSQL listening mode verified end-to-end on SI 4.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)