### PR TITLE
Fix Javadoc build failure on Java 11 after Debezium 2.x migration

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -622,6 +622,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/ChangeDataCapture.java
@@ -62,6 +62,8 @@ public abstract class ChangeDataCapture {
 
     /**
      * Initialize this.config according to user specified parameters.
+     *
+     * @param configMap map of configuration key-value pairs supplied by the user
      */
     public void setConfig(Map<String, Object> configMap) {
 
@@ -75,6 +77,7 @@ public abstract class ChangeDataCapture {
     /**
      * Create a new Debezium embedded engine with the configuration {@code config} and,
      *
+     * @param completionCallback callback invoked when the engine stops
      * @return {@code engine}.
      */
     public DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> getEngine(

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/CDCCronExecutor.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/CDCCronExecutor.java
@@ -49,6 +49,9 @@ public class CDCCronExecutor implements Job {
 
     /**
      * To initialize the cron job to execute at given cron expression
+     *
+     * @param pollingStrategy    the polling strategy to execute on each cron trigger
+     * @param cronConfiguration  the cron configuration containing the expression and scheduler
      */
     public static void scheduleJob(PollingStrategy pollingStrategy, CronConfiguration cronConfiguration) {
         try {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -280,6 +280,8 @@ public class CDCSourceUtil {
     /**
      * Get the WSO2 Stream Processor's local path from System Variables.
      * if carbon.home is not set, return the current project path. (for test cases and for use as a java library)
+     *
+     * @return the carbon home path, or the current working directory if carbon.home is not set
      */
     public static String getCarbonHome() {
         String path = System.getProperty(CDCSourceConstants.CARBON_HOME);


### PR DESCRIPTION
## Summary

- `maven-javadoc-plugin:2.10.3` (inherited from `org.wso2:wso2:5.3` parent POM) auto-injects a link to the Java 8 API docs (`http://docs.oracle.com/javase/8/docs/api/`). Java 11's javadoc tool treats packages from that external link as being in the unnamed module, producing a hard error (exit code 1): _"The code being documented uses modules but the packages defined in [Java 8 docs] are in the unnamed module."_
- This caused the release build (PR #91) to fail at the `attach-javadocs` phase despite all 15 tests passing.
- Fixed by overriding `maven-javadoc-plugin` in `component/pom.xml` with `<detectJavaApiLink>false</detectJavaApiLink>`, and added the five missing `@param`/`@return` Javadoc tags introduced during the Debezium 2.x API migration (`ChangeDataCapture`, `CDCCronExecutor`, `CDCSourceUtil`).

## Test plan

- [x] Build passes locally with JDK 11 (`mvn clean install`) — BUILD SUCCESS, all tests pass
- [ ] Verify Jenkins release build no longer fails at `attach-javadocs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)