### PR TITLE
Fix classpath conflicts when running in SI LS Runner environment

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -629,6 +629,76 @@
                     <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.debezium:*</include>
+                                    <include>org.apache.kafka:connect-api</include>
+                                    <include>org.apache.kafka:connect-json</include>
+                                    <include>org.apache.kafka:connect-runtime</include>
+                                    <include>org.apache.kafka:kafka-clients</include>
+                                    <include>com.github.shyiko:mysql-binlog-connector-java</include>
+                                    <include>org.antlr:antlr4-runtime</include>
+                                    <include>org.json:json</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
+                                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                                    <include>com.mysql:mysql-connector-j</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>io.siddhi.cdc.shaded.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.mysql</pattern>
+                                    <shadedPattern>io.siddhi.cdc.shaded.mysql</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.kafka:connect-runtime</artifact>
+                                    <includes>
+                                        <include>META-INF/services/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>**/StaticLoggerBinder.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -66,6 +66,7 @@ public class CDCSourceConstants {
     public static final String BEFORE = "before";
     public static final String AFTER = "after";
     public static final String CARBON_HOME = "carbon.home";
+    public static final String CARBON_HOME_ENV = "CARBON_HOME";
     public static final String USER_DIRECTORY = "user.dir";
     public static final String MODE = "mode";
     public static final String MODE_LISTENING = "listening";

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -285,7 +285,9 @@ public class CDCSourceUtil {
      */
     public static String getCarbonHome() {
         String path = System.getProperty(CDCSourceConstants.CARBON_HOME);
-
+        if (path == null) {
+            path = System.getenv(CDCSourceConstants.CARBON_HOME_ENV);
+        }
         if (path == null) {
             path = System.getProperty(CDCSourceConstants.USER_DIRECTORY);
         }


### PR DESCRIPTION
## Summary

Three separate `NoSuchMethodError` / filesystem errors caused the CDC MySQL extension to fail when run via the VS Code SI extension's LS Runner (flat classpath: `ls/*:lib/*:plugins/*`):

- **`NoSuchFieldError: JsonParser$Feature.ALLOW_RS_CONTROL_CHAR`** — The langserver fat jar embeds stale jackson classes (2015 vintage) which load before the newer jackson in `plugins/`. Debezium's `JsonReadFeature.<clinit>` references `ALLOW_RS_CONTROL_CHAR` which doesn't exist in the old version. Fixed by shading and relocating `com.fasterxml.jackson` → `io.siddhi.cdc.shaded.jackson` so debezium uses a self-consistent bundled copy.

- **`/cdc: Read-only file system`** — The LS Runner sets `CARBON_HOME` as a process env var but never passes `-Dcarbon.home` as a JVM system property. `getCarbonHome()` only checked `System.getProperty`, fell back to `user.dir=/`, and the schema history path became `/cdc/history/...` (blocked by macOS SIP). Fixed by adding `System.getenv("CARBON_HOME")` as a fallback in `getCarbonHome()`.

- **`NoSuchMethodError: CharsetMapping.getStaticCollationNameForCollationIndex(Integer)`** — SI ships `mysql-connector-java-8.0.18` in `lib/`, which loads before the CDC jar alphabetically on the flat classpath. Debezium 2.7.3 requires `mysql-connector-j 8.3.0` for this method. Fixed by shading and relocating `com.mysql` → `io.siddhi.cdc.shaded.mysql` so debezium's internal calls use the bundled 8.3.0 version regardless of what is on the host classpath.

## Test plan

- [ ] Run a Siddhi app with `@source(type='cdc', url='jdbc:mysql://...', operation='insert', ...)` in the VS Code SI editor
- [ ] Verify no `NoSuchFieldError` or `NoSuchMethodError` in the LS Runner log
- [ ] Verify schema history file is created under `${CARBON_HOME}/cdc/history/`
- [ ] Insert a row into the monitored MySQL table and confirm the CDC source emits the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)