### PR TITLE
Fix OSGi MANIFEST.MF lost in shaded JAR

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -699,6 +699,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>inject-osgi-manifest</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- The shade plugin strips META-INF/MANIFEST.MF from all
+                                     inputs including the project's own OSGi bundle. Extract
+                                     the bundle manifest and reinject it into the shaded JAR. -->
+                                <unzip src="${project.build.directory}/original-${project.build.finalName}.jar"
+                                       dest="${project.build.directory}/osgi-manifest-staging">
+                                    <patternset>
+                                        <include name="META-INF/MANIFEST.MF"/>
+                                    </patternset>
+                                </unzip>
+                                <zip destfile="${project.build.directory}/${project.build.finalName}.jar"
+                                     update="true">
+                                    <zipfileset dir="${project.build.directory}/osgi-manifest-staging"
+                                                includes="META-INF/MANIFEST.MF"/>
+                                </zip>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Problem

The `maven-shade-plugin` filter configuration uses `<artifact>*:*</artifact>` with `<exclude>META-INF/MANIFEST.MF</exclude>` to prevent dependency manifests from polluting the shaded JAR. However, this filter also strips the `META-INF/MANIFEST.MF` from the **project's own artifact** — the OSGi bundle produced by `maven-bundle-plugin`.

As a result, the shaded JAR (`siddhi-io-cdc-*.jar`) ends up with only a minimal manifest (no `Bundle-SymbolicName`, `Bundle-Version`, etc.), causing the WSO2 Carbon OSGi framework to reject it at startup:

```
java.io.IOException: Invalid OSGi bundle found in the lib folder
    at org.wso2.carbon.launcher.extensions.OSGiLibBundleDeployerUtils.getBundleInfo(...)
```

## Fix

Add a `maven-antrun-plugin` execution in the `package` phase (declared after `maven-shade-plugin` so it runs after shading) that:

1. Extracts `META-INF/MANIFEST.MF` from `original-${project.build.finalName}.jar` — the pre-shade OSGi bundle with all correct headers
2. Injects it into the shaded JAR, replacing the minimal manifest

This makes every `mvn package` automatically produce a shaded JAR that is also a valid OSGi bundle.

## Test plan

- [ ] Run `mvn package -DskipTests` and verify `unzip -p target/siddhi-io-cdc-*.jar META-INF/MANIFEST.MF` contains `Bundle-SymbolicName` and `Bundle-Version`
- [ ] Deploy the resulting JAR to a WSO2 SI / Carbon server `lib/` folder and confirm no "Invalid OSGi bundle" warning at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)