### PR TITLE
Fix MongoDB listening mode for the Debezium 2.x change event format

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,13 +49,15 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
     Map<String, Object> createMap(ConnectRecord connectRecord, String operation) {
         //Map to return
         Map<String, Object> detailsMap = new HashMap<>();
-        List<Object> transportProperties = new ArrayList();
         Struct record = (Struct) connectRecord.value();
         //get the change data object's operation.
         String op;
         try {
             op = (String) record.get(CDCSourceConstants.CONNECT_RECORD_OPERATION);
         } catch (NullPointerException | DataException ex) {
+            return detailsMap;
+        }
+        if (op == null) {
             return detailsMap;
         }
         //match the change data's operation with user specifying operation and proceed.
@@ -66,37 +69,33 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
                 op.equals(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION)) {
             switch (op) {
                 case CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION:
-                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
-                            transportProperties.add(CDCSourceConstants.INSERT));
-                    //append row details after insert.
-                    String insertString = (String) record.get(CDCSourceConstants.AFTER);
-                    JSONObject jsonObj = new JSONObject(insertString);
-                    detailsMap = getMongoDetailMap(jsonObj);
+                    //append document details after insert.
+                    String insertedDocument = getStringField(record, CDCSourceConstants.AFTER);
+                    if (insertedDocument != null) {
+                        detailsMap = getMongoDetailMap(new JSONObject(insertedDocument));
+                    }
+                    addTransportProperties(detailsMap, CDCSourceConstants.INSERT);
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION:
-                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
-                            transportProperties.add(CDCSourceConstants.DELETE));
-                    //append row details before delete.
-                    String deleteDocumentId = (String) ((Struct) connectRecord.key())
-                            .get(CDCSourceConstants.MONGO_COLLECTION_ID);
-                    JSONObject jsonObjId = new JSONObject(deleteDocumentId);
-                    detailsMap.put(CDCSourceConstants.MONGO_COLLECTION_ID,
-                            jsonObjId.get(CDCSourceConstants.MONGO_COLLECTION_OBJECT_ID));
-
+                    //only the document id is available for a delete.
+                    detailsMap.put(CDCSourceConstants.MONGO_COLLECTION_ID, getDocumentId(connectRecord));
+                    addTransportProperties(detailsMap, CDCSourceConstants.DELETE);
                     break;
                 case CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION:
-                    detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES,
-                            transportProperties.add(CDCSourceConstants.UPDATE));
-                    //append row details before update.
-                    String updateDocument = (String) record.get(CDCSourceConstants.MONGO_PATCH);
-                    JSONObject jsonObj1 = new JSONObject(updateDocument);
-                    JSONObject setJsonObj = (JSONObject) jsonObj1.get(CDCSourceConstants.MONGO_SET);
-                    detailsMap = getMongoDetailMap(setJsonObj);
-                    String updateDocumentId = (String) ((Struct) connectRecord.key())
-                            .get(CDCSourceConstants.MONGO_COLLECTION_ID);
-                    JSONObject jsonObjId1 = new JSONObject(updateDocumentId);
-                    detailsMap.put(CDCSourceConstants.MONGO_COLLECTION_ID,
-                            jsonObjId1.get(CDCSourceConstants.MONGO_COLLECTION_OBJECT_ID));
+                    /*
+                     * Debezium reports the changed fields of an update through updateDescription.updatedFields. A
+                     * replace, and a capture mode that omits the update description, carry the full document in
+                     * "after" instead; fall back to it so that those events are not dropped.
+                     */
+                    String updatedFields = getUpdatedFields(record);
+                    if (updatedFields == null) {
+                        updatedFields = getStringField(record, CDCSourceConstants.AFTER);
+                    }
+                    if (updatedFields != null) {
+                        detailsMap = getMongoDetailMap(new JSONObject(updatedFields));
+                    }
+                    detailsMap.put(CDCSourceConstants.MONGO_COLLECTION_ID, getDocumentId(connectRecord));
+                    addTransportProperties(detailsMap, CDCSourceConstants.UPDATE);
                     break;
                 default:
                     log.info("Provided value for \"op\" : {} is not supported.", op);
@@ -104,6 +103,72 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
             }
         }
         return detailsMap;
+    }
+
+    /**
+     * {@code ChangeDataCapture.handleEvent} expects this entry to be a {@link List}, so it has to be populated after
+     * any reassignment of the details map.
+     */
+    private void addTransportProperties(Map<String, Object> detailsMap, String operation) {
+        List<Object> transportProperties = new ArrayList<>();
+        transportProperties.add(operation);
+        detailsMap.put(CDCSourceConstants.TRANSPORT_PROPERTIES, transportProperties);
+    }
+
+    /**
+     * Reads the fields changed by an update from {@code updateDescription.updatedFields}.
+     *
+     * @return the changed fields as extended JSON, or null when the change event carries no update description.
+     */
+    private String getUpdatedFields(Struct record) {
+        Struct updateDescription;
+        try {
+            updateDescription = record.getStruct(CDCSourceConstants.MONGO_UPDATE_DESCRIPTION);
+        } catch (DataException ex) {
+            log.debug("Change event has no {} field.", CDCSourceConstants.MONGO_UPDATE_DESCRIPTION);
+            return null;
+        }
+        if (updateDescription == null) {
+            return null;
+        }
+        return getStringField(updateDescription, CDCSourceConstants.MONGO_UPDATED_FIELDS);
+    }
+
+    /**
+     * Resolves the document id from the change event key. An ObjectId is serialised as {@code {"$oid": "..."}} while
+     * other id types are serialised as bare JSON scalars.
+     */
+    private Object getDocumentId(ConnectRecord connectRecord) {
+        Struct key = (Struct) connectRecord.key();
+        if (key == null) {
+            return null;
+        }
+        String documentId = getStringField(key, CDCSourceConstants.MONGO_COLLECTION_ID);
+        if (documentId == null) {
+            return null;
+        }
+        try {
+            Object parsedId = new JSONTokener(documentId).nextValue();
+            if (parsedId instanceof JSONObject) {
+                JSONObject idObject = (JSONObject) parsedId;
+                if (idObject.has(CDCSourceConstants.MONGO_COLLECTION_OBJECT_ID)) {
+                    return idObject.get(CDCSourceConstants.MONGO_COLLECTION_OBJECT_ID);
+                }
+                return idObject.toString();
+            }
+            return parsedId;
+        } catch (JSONException ex) {
+            return documentId;
+        }
+    }
+
+    private String getStringField(Struct struct, String fieldName) {
+        try {
+            return struct.getString(fieldName);
+        } catch (DataException ex) {
+            log.debug("Change event has no {} field.", fieldName);
+            return null;
+        }
     }
 
     private Map<String, Object> getMongoDetailMap(JSONObject jsonObj) {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -93,8 +93,8 @@ public class CDCSourceConstants {
     public static final String MONGO_COLLECTION_OBJECT_ID = "$oid";
     public static final String MONGO_COLLECTION_ID = "id";
     public static final String MONGO_COLLECTION_INSERT_ID = "_id";
-    public static final String MONGO_PATCH = "patch";
-    public static final String MONGO_SET = "$set";
+    public static final String MONGO_UPDATE_DESCRIPTION = "updateDescription";
+    public static final String MONGO_UPDATED_FIELDS = "updatedFields";
     public static final String MONGO_OBJECT_NUMBER_LONG = "$numberLong";
     public static final String MONGO_OBJECT_NUMBER_DECIMAL = "$numberDecimal";
 

--- a/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCaptureTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCaptureTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.source.listening;
+
+import io.debezium.connector.mongodb.MongoDbFieldName;
+import io.debezium.connector.mongodb.MongoDbSchemaFactory;
+import io.debezium.data.Envelope;
+import io.debezium.data.Json;
+import io.siddhi.extension.io.cdc.util.CDCSourceConstants;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link MongoChangeDataCapture}, covering the translation of Debezium MongoDB change events into the
+ * detail map handed to Siddhi.
+ * <p>
+ * The event schemas are assembled from Debezium's own constants and schema factory rather than hand written strings,
+ * so that a future Debezium upgrade which renames or reshapes the change event fails these tests instead of silently
+ * producing empty streams at runtime.
+ */
+public class MongoChangeDataCaptureTest {
+
+    private static final String TOPIC = "test.SimpleDB.SweetProductionTable";
+    private static final String OBJECT_ID = "5f2b1c3d4e5f6a7b8c9d0e1f";
+
+    private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
+            .name("test.SimpleDB.SweetProductionTable.Key")
+            .field(CDCSourceConstants.MONGO_COLLECTION_ID, Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+
+    /**
+     * Mirrors the value schema Debezium's MongoDB connector produces: an envelope carrying the full document as
+     * relaxed extended JSON plus, for updates, the {@code updateDescription} struct built by Debezium itself.
+     */
+    private static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
+            .name("test.SimpleDB.SweetProductionTable.Envelope")
+            .field(Envelope.FieldName.AFTER, Json.builder().optional().build())
+            .field(Envelope.FieldName.BEFORE, Json.builder().optional().build())
+            .field(MongoDbFieldName.UPDATE_DESCRIPTION, MongoDbSchemaFactory.get().updatedDescriptionSchema())
+            .field(Envelope.FieldName.OPERATION, Schema.OPTIONAL_STRING_SCHEMA)
+            .field(Envelope.FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
+            .build();
+
+    private static MongoChangeDataCapture capture(String operation) {
+        return new MongoChangeDataCapture(operation, null, null);
+    }
+
+    private static SourceRecord record(Struct value) {
+        Struct key = new Struct(KEY_SCHEMA);
+        key.put(CDCSourceConstants.MONGO_COLLECTION_ID, "{\"$oid\": \"" + OBJECT_ID + "\"}");
+        return new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), TOPIC,
+                KEY_SCHEMA, key, VALUE_SCHEMA, value);
+    }
+
+    private static Struct value(String op) {
+        Struct value = new Struct(VALUE_SCHEMA);
+        value.put(Envelope.FieldName.OPERATION, op);
+        value.put(Envelope.FieldName.TIMESTAMP, 1700000000000L);
+        return value;
+    }
+
+    private static Struct updateDescription(String updatedFieldsJson) {
+        Struct updateDescription = new Struct(MongoDbSchemaFactory.get().updatedDescriptionSchema());
+        updateDescription.put(MongoDbFieldName.UPDATED_FIELDS, updatedFieldsJson);
+        return updateDescription;
+    }
+
+    /**
+     * Guards the field names this extension hardcodes against the constants Debezium actually publishes. This is the
+     * check that would have caught the {@code patch} to {@code updateDescription} rename in Debezium 2.x.
+     */
+    @Test
+    public void mongoFieldNamesMatchDebeziumConstants() {
+        Assert.assertEquals(CDCSourceConstants.MONGO_UPDATE_DESCRIPTION, MongoDbFieldName.UPDATE_DESCRIPTION,
+                "Debezium renamed the update description field");
+        Assert.assertEquals(CDCSourceConstants.MONGO_UPDATED_FIELDS, MongoDbFieldName.UPDATED_FIELDS,
+                "Debezium renamed the updated fields entry of the update description");
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_OPERATION, Envelope.FieldName.OPERATION);
+        Assert.assertEquals(CDCSourceConstants.AFTER, Envelope.FieldName.AFTER);
+        Assert.assertEquals(CDCSourceConstants.BEFORE, Envelope.FieldName.BEFORE);
+    }
+
+    @Test
+    public void insertEventCapturesTheFullDocument() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION);
+        value.put(Envelope.FieldName.AFTER,
+                "{\"_id\": {\"$oid\": \"" + OBJECT_ID + "\"}, \"name\": \"sweets\", \"amount\": 100.0, "
+                        + "\"volume\": 5}");
+
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT)
+                .createMap(record(value), CDCSourceConstants.INSERT);
+
+        Assert.assertEquals(detailsMap.get("name"), "sweets");
+        Assert.assertEquals(detailsMap.get("amount"), 100.0);
+        Assert.assertEquals(detailsMap.get("volume"), 5);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.MONGO_COLLECTION_ID), OBJECT_ID);
+    }
+
+    /**
+     * Debezium 2.x reports updates through {@code updateDescription.updatedFields} rather than the 1.x {@code patch}
+     * document. Only the changed fields are emitted, preserving the pre-upgrade contract.
+     */
+    @Test
+    public void updateEventCapturesChangedFieldsFromUpdateDescription() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION);
+        value.put(MongoDbFieldName.UPDATE_DESCRIPTION, updateDescription("{\"amount\": 500.0}"));
+
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.UPDATE)
+                .createMap(record(value), CDCSourceConstants.UPDATE);
+
+        Assert.assertEquals(detailsMap.get("amount"), 500.0);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.MONGO_COLLECTION_ID), OBJECT_ID);
+        Assert.assertFalse(detailsMap.containsKey("name"), "Only the updated fields should be emitted");
+    }
+
+    /**
+     * Under {@code capture.mode=change_streams} Debezium omits the full document but still reports the update
+     * description. Under the default {@code change_streams_update_full} both are present; the update description
+     * remains the source of truth so that the emitted attributes stay limited to what actually changed.
+     */
+    @Test
+    public void updateEventPrefersUpdateDescriptionOverFullDocument() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION);
+        value.put(Envelope.FieldName.AFTER,
+                "{\"_id\": {\"$oid\": \"" + OBJECT_ID + "\"}, \"name\": \"sweets\", \"amount\": 500.0}");
+        value.put(MongoDbFieldName.UPDATE_DESCRIPTION, updateDescription("{\"amount\": 500.0}"));
+
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.UPDATE)
+                .createMap(record(value), CDCSourceConstants.UPDATE);
+
+        Assert.assertEquals(detailsMap.get("amount"), 500.0);
+        Assert.assertFalse(detailsMap.containsKey("name"), "Only the updated fields should be emitted");
+    }
+
+    /**
+     * A replace operation carries a full document but no update description; falling back to the full document keeps
+     * those events flowing instead of dropping them.
+     */
+    @Test
+    public void updateEventFallsBackToFullDocumentWhenUpdateDescriptionIsAbsent() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION);
+        value.put(Envelope.FieldName.AFTER,
+                "{\"_id\": {\"$oid\": \"" + OBJECT_ID + "\"}, \"name\": \"sweets\", \"amount\": 500.0}");
+
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.UPDATE)
+                .createMap(record(value), CDCSourceConstants.UPDATE);
+
+        Assert.assertEquals(detailsMap.get("name"), "sweets");
+        Assert.assertEquals(detailsMap.get("amount"), 500.0);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.MONGO_COLLECTION_ID), OBJECT_ID);
+    }
+
+    @Test
+    public void deleteEventCapturesTheDocumentId() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.DELETE)
+                .createMap(record(value(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION)),
+                        CDCSourceConstants.DELETE);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.MONGO_COLLECTION_ID), OBJECT_ID);
+    }
+
+    /**
+     * {@code ChangeDataCapture.handleEvent} casts the transport properties entry to a {@link List}. Storing anything
+     * else there fails with a {@link ClassCastException} once the event reaches the source event listener.
+     */
+    @Test
+    public void transportPropertiesAreAListForEveryOperation() {
+        Struct insert = value(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION);
+        insert.put(Envelope.FieldName.AFTER, "{\"name\": \"sweets\"}");
+        Struct update = value(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION);
+        update.put(MongoDbFieldName.UPDATE_DESCRIPTION, updateDescription("{\"amount\": 500.0}"));
+        Struct delete = value(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION);
+
+        assertTransportProperties(capture(CDCSourceConstants.INSERT)
+                .createMap(record(insert), CDCSourceConstants.INSERT), CDCSourceConstants.INSERT);
+        assertTransportProperties(capture(CDCSourceConstants.UPDATE)
+                .createMap(record(update), CDCSourceConstants.UPDATE), CDCSourceConstants.UPDATE);
+        assertTransportProperties(capture(CDCSourceConstants.DELETE)
+                .createMap(record(delete), CDCSourceConstants.DELETE), CDCSourceConstants.DELETE);
+    }
+
+    private void assertTransportProperties(Map<String, Object> detailsMap, String expectedOperation) {
+        Object transportProperties = detailsMap.get(CDCSourceConstants.TRANSPORT_PROPERTIES);
+        Assert.assertTrue(transportProperties instanceof List,
+                "Transport properties must be a List for " + expectedOperation + " but was " + transportProperties);
+        Assert.assertEquals(((List) transportProperties).get(0), expectedOperation);
+    }
+
+    /**
+     * A document keyed by something other than an ObjectId serialises to a bare JSON scalar rather than an
+     * {@code {"$oid": ...}} wrapper, and must not blow up the engine.
+     */
+    @Test
+    public void deleteEventHandlesNonObjectIdKeys() {
+        Struct key = new Struct(KEY_SCHEMA);
+        key.put(CDCSourceConstants.MONGO_COLLECTION_ID, "\"e001\"");
+        SourceRecord sourceRecord = new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), TOPIC,
+                KEY_SCHEMA, key, VALUE_SCHEMA, value(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION));
+
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.DELETE)
+                .createMap(sourceRecord, CDCSourceConstants.DELETE);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.MONGO_COLLECTION_ID), "e001");
+    }
+
+    @Test
+    public void eventsNotMatchingTheConfiguredOperationAreIgnored() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION);
+        value.put(MongoDbFieldName.UPDATE_DESCRIPTION, updateDescription("{\"amount\": 500.0}"));
+
+        Assert.assertTrue(capture(CDCSourceConstants.INSERT)
+                .createMap(record(value), CDCSourceConstants.INSERT).isEmpty());
+    }
+
+    @Test
+    public void snapshotReadEventsAreIgnored() {
+        Struct value = value(CDCSourceConstants.CONNECT_RECORD_INITIAL_SYNC);
+        value.put(Envelope.FieldName.AFTER, "{\"name\": \"sweets\"}");
+
+        Assert.assertTrue(capture(CDCSourceConstants.INSERT)
+                .createMap(record(value), CDCSourceConstants.INSERT).isEmpty());
+    }
+}

--- a/component/src/test/resources/testng-suit1.xml
+++ b/component/src/test/resources/testng-suit1.xml
@@ -20,12 +20,14 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<!--This test suit is used to validate CDCSource and test H2 CDC in polling mode-->
+<!--This test suit is used to validate CDCSource, test H2 CDC in polling mode and unit test the change data
+    translation of the listening mode, which needs no database-->
 <suite name="Siddhi-Io-Cdc-Test-Suite1">
     <test name="Siddhi-io-cdc-tests-1" enabled="true" parallel="false">
         <classes>
             <class name="io.siddhi.extension.io.cdc.source.TestCaseOfCDCSourceValidation"/>
             <class name="io.siddhi.extension.io.cdc.source.TestCaseOfCDCPollingMode"/>
+            <class name="io.siddhi.extension.io.cdc.source.listening.MongoChangeDataCaptureTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose

Fixes MongoDB listening mode, which has been broken since the Debezium 2.7.3 upgrade. Debezium 2.x replaced the MongoDB `patch` field with `updateDescription`, and `MongoChangeDataCapture` was never updated to match.

Two of the three MongoDB operations fail outright today:

| Operation | Behaviour on 2.7.3 |
|---|---|
| insert | Works, but silently drops its transport properties |
| update | `DataException: patch is not a valid field name` |
| delete | `ClassCastException: class java.lang.Boolean cannot be cast to class java.util.List` |

Reproduced against the current `master` build:

```
insert  -> map={amount=100.0, name=sweets} | transportProperties: absent
update  -> *** THREW org.apache.kafka.connect.errors.DataException: patch is not a valid field name
delete  -> map={transportProperties=true, id=5f2b...} | handleEvent cast: *** ClassCastException:
           class java.lang.Boolean cannot be cast to class java.util.List
```

The delete failure is a separate latent bug: the transport properties entry was populated with the `boolean` returned by `List.add(...)` instead of the list itself, and `ChangeDataCapture.handleEvent` casts that entry to a `List`. Insert avoided the crash only because the details map was reassigned immediately afterwards, discarding the bad entry along with the transport properties.

This went unnoticed because `TestCaseOfCDCListeningModeMongo` is not referenced by any TestNG suite or Maven profile, and its connection parameters are placeholders — it has never run.

## Goals

- Read updates from `updateDescription.updatedFields`, preserving the pre-upgrade contract of emitting only the changed fields.
- Fall back to the full document in `after` for replace events and for capture modes that omit the update description, so those events are not dropped.
- Emit transport properties as a `List` for every operation.
- Resolve document ids from the change event key for updates and deletes, without failing on ids that are not `ObjectId`s.
- Add regression coverage that runs by default.

## Approach

`MongoChangeDataCaptureTest` builds change events from Debezium's own `MongoDbFieldName`, `MongoDbSchemaFactory` and `Envelope.FieldName` rather than hand written schemas, so a future Debezium upgrade that renames or reshapes the change event fails the build instead of silently producing empty streams. `mongoFieldNamesMatchDebeziumConstants` is the check that would have caught this rename during the 2.7.3 upgrade.

The tests need no database, so they are wired into `testng-suit1` and run under `mvn test`.

## Verification

`mvn clean test -Dspotbugs.skip=true` — 25 tests, 0 failures (15 before this change, 10 added).

`-Dspotbugs.skip=true` is needed only because the pinned SpotBugs 4.1.4 cannot read Java 17 class files; that is unrelated to this change and is being addressed separately.

## Known limitations, not addressed here

- `MongoChangeDataCapture` still does not support comma separated operations such as `operation = 'insert,update'`. `RdbmsChangeDataCapture` gained that support but the MongoDB path did not, so such a configuration silently matches nothing.
- `TestCaseOfCDCListeningModeMongo` remains a manual template with placeholder connection parameters. Covering MongoDB listening mode end to end is planned as part of moving the integration tests to Testcontainers.