### PR TITLE
Add tests to improve coverage

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/DefaultPollingStrategy.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/DefaultPollingStrategy.java
@@ -139,7 +139,9 @@ public class DefaultPollingStrategy extends PollingStrategy {
         PreparedStatement statement = null;
         boolean isError = false;
         try {
-            selectQuery = getSelectQuery("*", "WHERE " + pollingColumn + " > ?");
+            // Order by the polling column so that lastReadPollingColumnValue only ever moves forward. Without
+            // it, out of order rows leave the offset on a lower value and the rows above it are emitted again.
+            selectQuery = getSelectQuery("*", "WHERE " + pollingColumn + " > ? ORDER BY " + pollingColumn);
             statement = connection.prepareStatement(selectQuery);
             statement.setString(1, lastReadPollingColumnValue);
             resultSet = statement.executeQuery();

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/WaitOnMissingRecordPollingStrategy.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/strategies/WaitOnMissingRecordPollingStrategy.java
@@ -87,7 +87,10 @@ public class WaitOnMissingRecordPollingStrategy extends PollingStrategy {
                 }
             }
 
-            selectQuery = getSelectQuery("*", "WHERE " + pollingColumn + " > ?");
+            // Order by the polling column: the gap detection below compares each row against the previous one,
+            // so it is only correct on an ascending stream. Without it, a row physically stored before a lower
+            // valued one drags lastReadPollingColumnValue backwards and the higher row is emitted twice.
+            selectQuery = getSelectQuery("*", "WHERE " + pollingColumn + " > ? ORDER BY " + pollingColumn);
             statement = connection.prepareStatement(selectQuery);
 
             while (true) {

--- a/component/src/test/java/io/siddhi/extension/io/cdc/source/TestCaseOfCDCPollingMode.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/source/TestCaseOfCDCPollingMode.java
@@ -36,7 +36,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -349,10 +353,12 @@ public class TestCaseOfCDCPollingMode {
                 rdbmsStoreDefinition + rdbmsQuery);
         siddhiAppRuntime.addCallback("query2", rdbmsQueryCallback);
 
+        List<Object> receivedIds = Collections.synchronizedList(new ArrayList<>());
         StreamCallback outputStreamCallback = new StreamCallback() {
             @Override
             public void receive(Event[] events) {
                 for (Event event : events) {
+                    receivedIds.add(event.getData(0));
                     eventCount.getAndIncrement();
                     log.info(eventCount + ". " + event);
                 }
@@ -380,7 +386,12 @@ public class TestCaseOfCDCPollingMode {
 
         SiddhiTestHelper.waitForEvents(waitTime, 4, eventCount, timeout);
 
-        // Assert received event count.
+        // Let a few more polling intervals elapse. Asserting immediately races the next poll, which would hide a
+        // record being emitted twice.
+        Thread.sleep(pollingInterval * 3000L);
+
+        // Assert the records arrive exactly once each, in ascending order of the polling column.
+        Assert.assertEquals(receivedIds, Arrays.asList(1, 2, 3, 4));
         Assert.assertEquals(eventCount.get(), 4);
 
         siddhiAppRuntime.shutdown();

--- a/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCaptureTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCaptureTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.source.listening;
+
+import io.debezium.data.Envelope;
+import io.debezium.data.VariableScaleDecimal;
+import io.siddhi.extension.io.cdc.util.CDCSourceConstants;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link RdbmsChangeDataCapture}, covering the translation of Debezium change events into the detail
+ * map handed to Siddhi.
+ * <p>
+ * The change events are assembled through Debezium's own {@link Envelope} builder rather than hand written schemas,
+ * so an upgrade that reshapes the envelope fails here instead of silently producing empty streams at runtime.
+ */
+public class RdbmsChangeDataCaptureTest {
+
+    private static final String TOPIC = "testApp.SimpleDB.login";
+    private static final long SOURCE_TIMESTAMP = 1700000000000L;
+    private static final long EVENT_TIMESTAMP = 1700000000123L;
+    private static final String ALL_OPERATIONS = "insert,update,delete";
+
+    private static final Schema SOURCE_SCHEMA = SchemaBuilder.struct()
+            .name("test.Source")
+            .field(CDCSourceConstants.EVENT_TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
+            .build();
+
+    /**
+     * A row with one column per value conversion {@code RdbmsChangeDataCapture} performs.
+     */
+    private static final Schema ROW_SCHEMA = SchemaBuilder.struct()
+            .name("test.login.Value")
+            .field("id", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("amount", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("quantity", Schema.OPTIONAL_INT16_SCHEMA)
+            .field("flag", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("tiny", Schema.OPTIONAL_INT8_SCHEMA)
+            .field("price", VariableScaleDecimal.builder().optional().build())
+            .build();
+
+    private static final Envelope ENVELOPE = Envelope.defineSchema()
+            .withName("test.login.Envelope")
+            .withRecord(ROW_SCHEMA)
+            .withSource(SOURCE_SCHEMA)
+            .build();
+
+    private static RdbmsChangeDataCapture capture(String operation) {
+        return new RdbmsChangeDataCapture(operation, null, null);
+    }
+
+    private static Struct row(String id, String name, Double amount, Short quantity, Boolean flag, Byte tiny,
+                              BigDecimal price) {
+        Struct row = new Struct(ROW_SCHEMA);
+        row.put("id", id);
+        row.put("name", name);
+        row.put("amount", amount);
+        row.put("quantity", quantity);
+        row.put("flag", flag);
+        row.put("tiny", tiny);
+        if (price != null) {
+            row.put("price", VariableScaleDecimal.fromLogical(
+                    VariableScaleDecimal.builder().optional().build(), price));
+        }
+        return row;
+    }
+
+    private static Struct simpleRow(String id, String name) {
+        return row(id, name, 100.0, (short) 5, true, (byte) 3, new BigDecimal("12.34"));
+    }
+
+    private static SourceRecord record(String op, Struct before, Struct after) {
+        Struct source = new Struct(SOURCE_SCHEMA);
+        source.put(CDCSourceConstants.EVENT_TIMESTAMP, SOURCE_TIMESTAMP);
+
+        Struct value = new Struct(ENVELOPE.schema());
+        value.put(Envelope.FieldName.OPERATION, op);
+        value.put(Envelope.FieldName.SOURCE, source);
+        value.put(Envelope.FieldName.TIMESTAMP, EVENT_TIMESTAMP);
+        if (before != null) {
+            value.put(Envelope.FieldName.BEFORE, before);
+        }
+        if (after != null) {
+            value.put(Envelope.FieldName.AFTER, after);
+        }
+        return new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), TOPIC, null, null,
+                ENVELOPE.schema(), value);
+    }
+
+    /**
+     * The envelope this extension reads from is Debezium's, so confirm it still exposes the fields being read.
+     */
+    @Test
+    public void envelopeExposesTheFieldsTheExtensionReads() {
+        Schema schema = ENVELOPE.schema();
+        Assert.assertNotNull(schema.field(CDCSourceConstants.CONNECT_RECORD_OPERATION));
+        Assert.assertNotNull(schema.field(CDCSourceConstants.BEFORE));
+        Assert.assertNotNull(schema.field(CDCSourceConstants.AFTER));
+        Assert.assertNotNull(schema.field(CDCSourceConstants.SOURCE_SCHEMA));
+        Assert.assertNotNull(schema.field(CDCSourceConstants.EVENT_TIMESTAMP));
+        Assert.assertNotNull(schema.field(CDCSourceConstants.SOURCE_SCHEMA).schema()
+                .field(CDCSourceConstants.EVENT_TIMESTAMP));
+    }
+
+    @Test
+    public void insertEmitsTheAfterImage() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null, simpleRow("e001", "employer")),
+                CDCSourceConstants.INSERT);
+
+        Assert.assertEquals(detailsMap.get("id"), "e001");
+        Assert.assertEquals(detailsMap.get("name"), "employer");
+        Assert.assertFalse(detailsMap.containsKey(CDCSourceConstants.BEFORE_PREFIX + "id"),
+                "Single operation mode should not emit a before image for an insert");
+    }
+
+    @Test
+    public void deleteEmitsTheBeforeImage() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.DELETE).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION, simpleRow("e001", "employer"), null),
+                CDCSourceConstants.DELETE);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "id"), "e001");
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "name"), "employer");
+        Assert.assertFalse(detailsMap.containsKey("id"),
+                "Single operation mode should not emit an after image for a delete");
+    }
+
+    @Test
+    public void updateEmitsBothImages() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.UPDATE).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION, simpleRow("e001", "old"),
+                        simpleRow("e001", "new")),
+                CDCSourceConstants.UPDATE);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "name"), "old");
+        Assert.assertEquals(detailsMap.get("name"), "new");
+    }
+
+    /**
+     * With several operations configured, one Siddhi stream receives all of them, so the absent image is padded with
+     * type defaults to keep the attribute set stable across events.
+     */
+    @Test
+    public void multiOperationInsertPadsTheBeforeImageWithDefaults() {
+        Map<String, Object> detailsMap = capture(ALL_OPERATIONS).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null, simpleRow("e001", "employer")),
+                ALL_OPERATIONS);
+
+        Assert.assertEquals(detailsMap.get("id"), "e001");
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "id"), "");
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "amount"), 0.0);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "flag"), false);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "quantity"), 0);
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "price"), 0);
+    }
+
+    @Test
+    public void multiOperationDeletePadsTheAfterImageWithDefaults() {
+        Map<String, Object> detailsMap = capture(ALL_OPERATIONS).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION, simpleRow("e001", "employer"), null),
+                ALL_OPERATIONS);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "id"), "e001");
+        Assert.assertEquals(detailsMap.get("id"), "");
+        Assert.assertEquals(detailsMap.get("amount"), 0.0);
+        Assert.assertEquals(detailsMap.get("flag"), false);
+    }
+
+    @Test
+    public void multiOperationUpdateEmitsBothImages() {
+        Map<String, Object> detailsMap = capture(ALL_OPERATIONS).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION, simpleRow("e001", "old"),
+                        simpleRow("e001", "new")),
+                ALL_OPERATIONS);
+
+        Assert.assertEquals(detailsMap.get(CDCSourceConstants.BEFORE_PREFIX + "name"), "old");
+        Assert.assertEquals(detailsMap.get("name"), "new");
+    }
+
+    @Test
+    public void multiOperationListToleratesWhitespace() {
+        Map<String, Object> detailsMap = capture("insert, update , delete").createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null, simpleRow("e001", "employer")),
+                "insert, update , delete");
+
+        Assert.assertEquals(detailsMap.get("id"), "e001");
+    }
+
+    /**
+     * Siddhi has no 16 or 8 bit integer type, so these are widened rather than passed through as Short and Byte.
+     */
+    @Test
+    public void shortAndByteColumnsAreWidenedToInteger() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null,
+                        row("e001", "employer", 1.0, (short) 42, true, (byte) 7, null)),
+                CDCSourceConstants.INSERT);
+
+        Assert.assertEquals(detailsMap.get("quantity"), 42);
+        Assert.assertEquals(detailsMap.get("tiny"), 7);
+    }
+
+    @Test
+    public void variableScaleDecimalWithoutAFractionBecomesLong() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null,
+                        row("e001", "employer", 1.0, (short) 1, true, (byte) 1, new BigDecimal("500.00"))),
+                CDCSourceConstants.INSERT);
+
+        Assert.assertEquals(detailsMap.get("price"), 500L);
+    }
+
+    @Test
+    public void variableScaleDecimalWithAFractionBecomesDouble() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null,
+                        row("e001", "employer", 1.0, (short) 1, true, (byte) 1, new BigDecimal("123.45"))),
+                CDCSourceConstants.INSERT);
+
+        Assert.assertEquals(detailsMap.get("price"), 123.45);
+    }
+
+    @Test
+    public void transportPropertiesCarryTheOperationAndTimestamps() {
+        Map<String, Object> detailsMap = capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, null, simpleRow("e001", "employer")),
+                CDCSourceConstants.INSERT);
+
+        List transportProperties = (List) detailsMap.get(CDCSourceConstants.TRANSPORT_PROPERTIES);
+        Assert.assertEquals(transportProperties.get(0), CDCSourceConstants.INSERT);
+        Assert.assertEquals(transportProperties.get(1), SOURCE_TIMESTAMP);
+        Assert.assertEquals(transportProperties.get(2), EVENT_TIMESTAMP);
+    }
+
+    @Test
+    public void eventsNotMatchingTheConfiguredOperationAreIgnored() {
+        Assert.assertTrue(capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION, simpleRow("e001", "old"),
+                        simpleRow("e001", "new")),
+                CDCSourceConstants.INSERT).isEmpty());
+    }
+
+    /**
+     * Snapshot records carry the read operation, which is not one a user can subscribe to.
+     */
+    @Test
+    public void snapshotReadEventsAreIgnored() {
+        Assert.assertTrue(capture(CDCSourceConstants.INSERT).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INITIAL_SYNC, null, simpleRow("e001", "employer")),
+                CDCSourceConstants.INSERT).isEmpty());
+
+        Assert.assertTrue(capture(ALL_OPERATIONS).createMap(
+                record(CDCSourceConstants.CONNECT_RECORD_INITIAL_SYNC, null, simpleRow("e001", "employer")),
+                ALL_OPERATIONS).isEmpty());
+    }
+
+    /**
+     * Debezium emits schema change and heartbeat records without an operation; these must be skipped rather than
+     * failing the engine.
+     */
+    @Test
+    public void recordsWithoutAnOperationFieldAreIgnored() {
+        Schema schemaWithoutOperation = SchemaBuilder.struct().name("test.NoOp")
+                .field("unrelated", Schema.OPTIONAL_STRING_SCHEMA).build();
+        Struct value = new Struct(schemaWithoutOperation);
+        value.put("unrelated", "value");
+        SourceRecord sourceRecord = new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), TOPIC,
+                null, null, schemaWithoutOperation, value);
+
+        Assert.assertTrue(capture(CDCSourceConstants.INSERT)
+                .createMap(sourceRecord, CDCSourceConstants.INSERT).isEmpty());
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCPollingUtilTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCPollingUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.util;
+
+import io.siddhi.extension.io.cdc.source.polling.CDCPollingModeException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Unit tests for {@link CDCPollingUtil}, which parses the {@code pool.properties} value used to configure the Hikari
+ * connection pool in polling mode.
+ */
+public class CDCPollingUtilTest {
+
+    @Test
+    public void isEmptyRecognisesNullBlankAndWhitespace() {
+        Assert.assertTrue(CDCPollingUtil.isEmpty(null));
+        Assert.assertTrue(CDCPollingUtil.isEmpty(""));
+        Assert.assertTrue(CDCPollingUtil.isEmpty("   "));
+        Assert.assertFalse(CDCPollingUtil.isEmpty("value"));
+        Assert.assertFalse(CDCPollingUtil.isEmpty("  value  "));
+    }
+
+    @Test
+    public void poolPropertiesAreSplitIntoTrimmedPairs() {
+        List<String[]> pairs = CDCPollingUtil.processKeyValuePairs(
+                "maximumPoolSize:10, idleTimeout : 60000,connectionTimeout:30000");
+
+        Assert.assertEquals(pairs.size(), 3);
+        Assert.assertEquals(pairs.get(0), new String[]{"maximumPoolSize", "10"});
+        Assert.assertEquals(pairs.get(1), new String[]{"idleTimeout", "60000"});
+        Assert.assertEquals(pairs.get(2), new String[]{"connectionTimeout", "30000"});
+    }
+
+    @Test
+    public void emptyPoolPropertiesProduceNoPairs() {
+        Assert.assertTrue(CDCPollingUtil.processKeyValuePairs(null).isEmpty());
+        Assert.assertTrue(CDCPollingUtil.processKeyValuePairs("").isEmpty());
+        Assert.assertTrue(CDCPollingUtil.processKeyValuePairs("   ").isEmpty());
+    }
+
+    @Test(expectedExceptions = CDCPollingModeException.class)
+    public void aPropertyWithoutASeparatorIsRejected() {
+        CDCPollingUtil.processKeyValuePairs("maximumPoolSize10");
+    }
+
+    @Test(expectedExceptions = CDCPollingModeException.class)
+    public void aPropertyWithTooManySeparatorsIsRejected() {
+        CDCPollingUtil.processKeyValuePairs("maximumPoolSize:10:20");
+    }
+
+    /**
+     * Closing null artifacts is the normal path when a query fails before the statement is created.
+     */
+    @Test
+    public void cleanupToleratesNullArtifacts() {
+        CDCPollingUtil.cleanupConnection(null, null, null);
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCSourceUtilTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCSourceUtilTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.util;
+
+import io.siddhi.extension.io.cdc.source.listening.InMemoryOffsetBackingStore;
+import io.siddhi.extension.io.cdc.source.listening.WrongConfigurationException;
+import io.siddhi.query.api.exception.SiddhiAppValidationException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Golden tests for the Debezium configuration {@link CDCSourceUtil#getConfigMap} assembles for each supported
+ * database. The whole map is asserted rather than individual entries, so that an upgrade which adds, drops or renames
+ * an entry shows up as a diff instead of passing unnoticed.
+ *
+ * @see DebeziumConfigContractTest for the checks that the keys themselves are still the ones Debezium expects.
+ */
+public class CDCSourceUtilTest {
+
+    private static final String HISTORY_FILE_DIRECTORY = "/tmp/cdc/history/";
+    private static final String SIDDHI_APP_NAME = "testApp";
+    private static final String STREAM_NAME = "testStream";
+    private static final String TABLE_NAME = "login";
+    private static final int SERVER_ID = 5555;
+    private static final int SOURCE_HASH_CODE = 1234;
+
+    private Map<String, Object> configMapFor(String url, String connectorProperties)
+            throws WrongConfigurationException {
+        return CDCSourceUtil.getConfigMap("myuser", "mypassword", url, TABLE_NAME, HISTORY_FILE_DIRECTORY,
+                SIDDHI_APP_NAME, STREAM_NAME, SERVER_ID, "", connectorProperties, SOURCE_HASH_CODE, null,
+                CDCSourceConstants.DECORDERBUFS_PLUGIN);
+    }
+
+    /**
+     * The settings every connector receives regardless of the database type.
+     */
+    private Map<String, Object> commonEntries(String expectedTopicPrefix) {
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(CDCSourceConstants.DATABASE_SERVER_ID, SERVER_ID);
+        expected.put(CDCSourceConstants.DATABASE_SERVER_NAME, expectedTopicPrefix);
+        expected.put(CDCSourceConstants.OFFSET_STORAGE, InMemoryOffsetBackingStore.class.getName());
+        expected.put(CDCSourceConstants.CDC_SOURCE_OBJECT, SOURCE_HASH_CODE);
+        expected.put(CDCSourceConstants.DATABASE_HISTORY, CDCSourceConstants.DATABASE_HISTORY_FILEBASE_HISTORY);
+        expected.put(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME, HISTORY_FILE_DIRECTORY + STREAM_NAME + ".dat");
+        expected.put(CDCSourceConstants.CONNECTOR_NAME, SIDDHI_APP_NAME + STREAM_NAME);
+        return expected;
+    }
+
+    @Test
+    public void mysqlUrlProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("localhost_3306");
+        expected.put(CDCSourceConstants.DATABASE_HOSTNAME, "localhost");
+        expected.put(CDCSourceConstants.DATABASE_PORT, 3306);
+        expected.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, "SimpleDB." + TABLE_NAME);
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.MYSQL_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.DATABASE_USER, "myuser");
+        expected.put(CDCSourceConstants.DATABASE_PASSWORD, "mypassword");
+
+        Assert.assertEquals(configMapFor("jdbc:mysql://localhost:3306/SimpleDB", ""), expected);
+    }
+
+    @Test
+    public void postgresUrlProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("localhost_5432");
+        expected.put(CDCSourceConstants.DATABASE_HOSTNAME, "localhost");
+        expected.put(CDCSourceConstants.DATABASE_PORT, 5432);
+        expected.put(CDCSourceConstants.DATABASE_DBNAME, "SimpleDB");
+        expected.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, TABLE_NAME);
+        expected.put(CDCSourceConstants.PLUGIN_NAME, CDCSourceConstants.DECORDERBUFS_PLUGIN);
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.POSTGRESQL_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.DATABASE_USER, "myuser");
+        expected.put(CDCSourceConstants.DATABASE_PASSWORD, "mypassword");
+
+        Assert.assertEquals(configMapFor("jdbc:postgresql://localhost:5432/SimpleDB", ""), expected);
+    }
+
+    @Test
+    public void sqlServerUrlProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("localhost_1433");
+        expected.put(CDCSourceConstants.DATABASE_HOSTNAME, "localhost");
+        expected.put(CDCSourceConstants.DATABASE_PORT, 1433);
+        expected.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, TABLE_NAME);
+        expected.put(CDCSourceConstants.SQLSERVER_DATABASE_NAMES, "SimpleDB");
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.DATABASE_USER, "myuser");
+        expected.put(CDCSourceConstants.DATABASE_PASSWORD, "mypassword");
+
+        Assert.assertEquals(configMapFor("jdbc:sqlserver://localhost:1433;databaseName=SimpleDB", ""), expected);
+    }
+
+    @Test
+    public void oracleUrlProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("localhost_1521");
+        expected.put(CDCSourceConstants.DATABASE_HOSTNAME, "localhost");
+        expected.put(CDCSourceConstants.DATABASE_PORT, 1521);
+        expected.put(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST, TABLE_NAME);
+        expected.put(CDCSourceConstants.DATABASE_DBNAME, "XE");
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.ORACLE_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.DATABASE_USER, "myuser");
+        expected.put(CDCSourceConstants.DATABASE_PASSWORD, "mypassword");
+        expected.put(CDCSourceConstants.ORACLE_OUTSERVER_PROPERTY_NAME, "dbzxout");
+
+        Assert.assertEquals(configMapFor("jdbc:oracle:thin:@localhost:1521/XE",
+                CDCSourceConstants.ORACLE_OUTSERVER_PROPERTY_NAME + "=dbzxout"), expected);
+    }
+
+    /**
+     * Records existing behaviour rather than endorsing it: the SID form of an Oracle URL, which is what the Oracle
+     * integration profile uses, leaves {@code database.dbname} empty because the URL pattern only recognises a SID
+     * introduced by a slash.
+     */
+    @Test
+    public void oracleSidUrlLeavesTheDatabaseNameEmpty() throws WrongConfigurationException {
+        Map<String, Object> configMap = configMapFor("jdbc:oracle:thin:@localhost:1521:XE",
+                CDCSourceConstants.ORACLE_OUTSERVER_PROPERTY_NAME + "=dbzxout");
+
+        Assert.assertEquals(configMap.get(CDCSourceConstants.DATABASE_DBNAME), "");
+        Assert.assertEquals(configMap.get(CDCSourceConstants.DATABASE_HOSTNAME), "localhost");
+        Assert.assertEquals(configMap.get(CDCSourceConstants.DATABASE_PORT), 1521);
+    }
+
+    @Test(expectedExceptions = WrongConfigurationException.class)
+    public void oracleWithoutTheOutServerPropertyIsRejected() throws WrongConfigurationException {
+        configMapFor("jdbc:oracle:thin:@localhost:1521/XE", "");
+    }
+
+    @Test
+    public void mongoReplicaSetUrlProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("rs0/localhost_27017");
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.MONGODB_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.MONGODB_CONNECTION_STRING, "mongodb://localhost:27017/?replicaSet=rs0");
+        expected.put(CDCSourceConstants.MONGODB_COLLECTION_INCLUDE_LIST, "SimpleDB." + TABLE_NAME);
+        expected.put(CDCSourceConstants.MONGODB_USER, "myuser");
+        expected.put(CDCSourceConstants.MONGODB_PASSWORD, "mypassword");
+
+        Assert.assertEquals(configMapFor("jdbc:mongodb://rs0/localhost:27017/SimpleDB", ""), expected);
+    }
+
+    @Test
+    public void mongoUrlWithoutAReplicaSetProducesTheExpectedConfiguration() throws WrongConfigurationException {
+        Map<String, Object> expected = commonEntries("localhost_27017");
+        expected.put(CDCSourceConstants.CONNECTOR_CLASS, CDCSourceConstants.MONGODB_CONNECTOR_CLASS);
+        expected.put(CDCSourceConstants.MONGODB_CONNECTION_STRING, "mongodb://localhost:27017/");
+        expected.put(CDCSourceConstants.MONGODB_COLLECTION_INCLUDE_LIST, "SimpleDB." + TABLE_NAME);
+        expected.put(CDCSourceConstants.MONGODB_USER, "myuser");
+        expected.put(CDCSourceConstants.MONGODB_PASSWORD, "mypassword");
+
+        Assert.assertEquals(configMapFor("jdbc:mongodb://localhost:27017/SimpleDB", ""), expected);
+    }
+
+    /**
+     * MongoDB authenticates through the dedicated mongodb.* settings, not the relational ones.
+     */
+    @Test
+    public void mongoCredentialsDoNotUseTheRelationalKeys() throws WrongConfigurationException {
+        Map<String, Object> configMap = configMapFor("jdbc:mongodb://localhost:27017/SimpleDB", "");
+
+        Assert.assertFalse(configMap.containsKey(CDCSourceConstants.DATABASE_USER));
+        Assert.assertFalse(configMap.containsKey(CDCSourceConstants.DATABASE_PASSWORD));
+    }
+
+    @Test
+    public void explicitServerNameOverridesTheHostPortDefault() throws WrongConfigurationException {
+        Map<String, Object> configMap = CDCSourceUtil.getConfigMap("myuser", "mypassword",
+                "jdbc:mysql://localhost:3306/SimpleDB", TABLE_NAME, HISTORY_FILE_DIRECTORY, SIDDHI_APP_NAME,
+                STREAM_NAME, SERVER_ID, "myTopicPrefix", "", SOURCE_HASH_CODE, null,
+                CDCSourceConstants.DECORDERBUFS_PLUGIN);
+
+        Assert.assertEquals(configMap.get(CDCSourceConstants.DATABASE_SERVER_NAME), "myTopicPrefix");
+    }
+
+    @Test
+    public void defaultServerIdIsRandomisedWithinTheExpectedRange() throws WrongConfigurationException {
+        for (int i = 0; i < 50; i++) {
+            Map<String, Object> configMap = CDCSourceUtil.getConfigMap("myuser", "mypassword",
+                    "jdbc:mysql://localhost:3306/SimpleDB", TABLE_NAME, HISTORY_FILE_DIRECTORY, SIDDHI_APP_NAME,
+                    STREAM_NAME, CDCSourceConstants.DEFAULT_SERVER_ID, "", "", SOURCE_HASH_CODE, null,
+                    CDCSourceConstants.DECORDERBUFS_PLUGIN);
+
+            int serverId = (Integer) configMap.get(CDCSourceConstants.DATABASE_SERVER_ID);
+            Assert.assertTrue(serverId >= 5400 && serverId <= 6400, "Unexpected generated server id: " + serverId);
+        }
+    }
+
+    @Test
+    public void connectorPropertiesAreAppendedToTheConfiguration() throws WrongConfigurationException {
+        Map<String, Object> configMap = configMapFor("jdbc:mysql://localhost:3306/SimpleDB",
+                "snapshot.mode=schema_only,max.batch.size=1024");
+
+        Assert.assertEquals(configMap.get("snapshot.mode"), "schema_only");
+        Assert.assertEquals(configMap.get("max.batch.size"), "1024");
+    }
+
+    @Test
+    public void connectorPropertiesCanOverrideAGeneratedSetting() throws WrongConfigurationException {
+        Map<String, Object> configMap = configMapFor("jdbc:mysql://localhost:3306/SimpleDB",
+                CDCSourceConstants.DATABASE_SERVER_NAME + "=overridden");
+
+        Assert.assertEquals(configMap.get(CDCSourceConstants.DATABASE_SERVER_NAME), "overridden");
+    }
+
+    @Test(expectedExceptions = SiddhiAppValidationException.class)
+    public void malformedConnectorPropertiesAreRejected() throws WrongConfigurationException {
+        configMapFor("jdbc:mysql://localhost:3306/SimpleDB", "snapshot.mode");
+    }
+
+    @Test(expectedExceptions = WrongConfigurationException.class)
+    public void nonJdbcUrlIsRejected() throws WrongConfigurationException {
+        configMapFor("mysql://localhost:3306/SimpleDB", "");
+    }
+
+    @Test(expectedExceptions = WrongConfigurationException.class)
+    public void unsupportedDatabaseSchemeIsRejected() throws WrongConfigurationException {
+        configMapFor("jdbc:db2://localhost:50000/SimpleDB", "");
+    }
+
+    @Test(expectedExceptions = WrongConfigurationException.class)
+    public void mysqlUrlWithoutAPortIsRejected() throws WrongConfigurationException {
+        configMapFor("jdbc:mysql://localhost/SimpleDB", "");
+    }
+
+    @Test(expectedExceptions = WrongConfigurationException.class)
+    public void sqlServerUrlWithoutADatabaseNameIsRejected() throws WrongConfigurationException {
+        configMapFor("jdbc:sqlserver://localhost:1433", "");
+    }
+
+    @Test
+    public void carbonHomeFallsBackToTheWorkingDirectory() {
+        Assert.assertEquals(CDCSourceUtil.getCarbonHome(), System.getProperty(CDCSourceConstants.USER_DIRECTORY));
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/DebeziumConfigContractTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/DebeziumConfigContractTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.util;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.binlog.BinlogConnectorConfig;
+import io.debezium.connector.mongodb.MongoDbConnectorConfig;
+import io.debezium.connector.mongodb.MongoDbFieldName;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
+import io.debezium.data.Envelope;
+import io.debezium.embedded.EmbeddedEngineConfig;
+import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.storage.file.history.FileSchemaHistory;
+import io.siddhi.extension.io.cdc.source.listening.WrongConfigurationException;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pins the Debezium and Kafka Connect configuration keys this extension hardcodes against the constants those
+ * libraries actually publish.
+ * <p>
+ * Debezium silently ignores configuration properties it does not recognise, so a renamed key produces a source that
+ * starts up, logs nothing and emits no events. Nothing else in the test suite can detect that. These tests are
+ * deliberately cheap and database free so that they can be run before and after a dependency upgrade.
+ */
+public class DebeziumConfigContractTest {
+
+    private static final String HISTORY_FILE_DIRECTORY = "/tmp/cdc/history/";
+    private static final String SIDDHI_APP_NAME = "testApp";
+    private static final String STREAM_NAME = "testStream";
+
+    /**
+     * Keys that are consumed by the embedded engine or the schema history storage module rather than by a connector,
+     * so they legitimately do not appear in any connector ConfigDef. Each is separately pinned to its owning
+     * constant by {@link #engineAndStorageKeysMatchDebeziumConstants()}.
+     */
+    private static final Set<String> NON_CONNECTOR_KEYS = new HashSet<>(Arrays.asList(
+            CDCSourceConstants.CONNECTOR_CLASS,
+            CDCSourceConstants.CONNECTOR_NAME,
+            CDCSourceConstants.OFFSET_STORAGE,
+            CDCSourceConstants.DATABASE_HISTORY,
+            CDCSourceConstants.DATABASE_HISTORY_FILE_NAME,
+            CDCSourceConstants.CDC_SOURCE_OBJECT));
+
+    @Test
+    public void connectorLevelKeysMatchDebeziumConstants() {
+        Assert.assertEquals(CDCSourceConstants.DATABASE_HOSTNAME, RelationalDatabaseConnectorConfig.HOSTNAME.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_PORT, RelationalDatabaseConnectorConfig.PORT.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_USER, RelationalDatabaseConnectorConfig.USER.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_PASSWORD, RelationalDatabaseConnectorConfig.PASSWORD.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_DBNAME,
+                RelationalDatabaseConnectorConfig.DATABASE_NAME.name());
+        Assert.assertEquals(CDCSourceConstants.TABLE_TABLE_INCLUDE_LIST,
+                RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_SERVER_NAME, CommonConnectorConfig.TOPIC_PREFIX.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_SERVER_ID, BinlogConnectorConfig.SERVER_ID.name());
+        Assert.assertEquals(CDCSourceConstants.PLUGIN_NAME, PostgresConnectorConfig.PLUGIN_NAME.name());
+        Assert.assertEquals(CDCSourceConstants.SQLSERVER_DATABASE_NAMES,
+                SqlServerConnectorConfig.DATABASE_NAMES.name());
+        Assert.assertEquals(CDCSourceConstants.MONGODB_CONNECTION_STRING,
+                MongoDbConnectorConfig.CONNECTION_STRING.name());
+        Assert.assertEquals(CDCSourceConstants.MONGODB_COLLECTION_INCLUDE_LIST,
+                MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST.name());
+        Assert.assertEquals(CDCSourceConstants.MONGODB_USER, MongoDbConnectorConfig.USER.name());
+        Assert.assertEquals(CDCSourceConstants.MONGODB_PASSWORD, MongoDbConnectorConfig.PASSWORD.name());
+    }
+
+    @Test
+    public void engineAndStorageKeysMatchDebeziumConstants() {
+        Assert.assertEquals(CDCSourceConstants.CONNECTOR_NAME, EmbeddedEngineConfig.ENGINE_NAME.name());
+        Assert.assertEquals(CDCSourceConstants.CONNECTOR_CLASS, EmbeddedEngineConfig.CONNECTOR_CLASS.name());
+        Assert.assertEquals(CDCSourceConstants.OFFSET_STORAGE, EmbeddedEngineConfig.OFFSET_STORAGE.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_HISTORY,
+                HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME, FileSchemaHistory.FILE_PATH.name());
+        Assert.assertEquals(CDCSourceConstants.DATABASE_HISTORY_FILEBASE_HISTORY, FileSchemaHistory.class.getName());
+    }
+
+    @Test
+    public void changeEventFieldNamesMatchDebeziumConstants() {
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_OPERATION, Envelope.FieldName.OPERATION);
+        Assert.assertEquals(CDCSourceConstants.BEFORE, Envelope.FieldName.BEFORE);
+        Assert.assertEquals(CDCSourceConstants.AFTER, Envelope.FieldName.AFTER);
+        Assert.assertEquals(CDCSourceConstants.SOURCE_SCHEMA, Envelope.FieldName.SOURCE);
+        Assert.assertEquals(CDCSourceConstants.EVENT_TIMESTAMP, Envelope.FieldName.TIMESTAMP);
+        Assert.assertEquals(CDCSourceConstants.MONGO_UPDATE_DESCRIPTION, MongoDbFieldName.UPDATE_DESCRIPTION);
+        Assert.assertEquals(CDCSourceConstants.MONGO_UPDATED_FIELDS, MongoDbFieldName.UPDATED_FIELDS);
+    }
+
+    @Test
+    public void changeEventOperationCodesMatchDebeziumConstants() {
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_INSERT_OPERATION, Envelope.Operation.CREATE.code());
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_UPDATE_OPERATION, Envelope.Operation.UPDATE.code());
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_DELETE_OPERATION, Envelope.Operation.DELETE.code());
+        Assert.assertEquals(CDCSourceConstants.CONNECT_RECORD_INITIAL_SYNC, Envelope.Operation.READ.code());
+    }
+
+    @DataProvider(name = "connectorClasses")
+    public Object[][] connectorClasses() {
+        return new Object[][]{
+                {CDCSourceConstants.MYSQL_CONNECTOR_CLASS},
+                {CDCSourceConstants.POSTGRESQL_CONNECTOR_CLASS},
+                {CDCSourceConstants.ORACLE_CONNECTOR_CLASS},
+                {CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS},
+                {CDCSourceConstants.MONGODB_CONNECTOR_CLASS}
+        };
+    }
+
+    /**
+     * A connector class that has been moved or renamed fails only when a Siddhi app starts, so resolve them up front.
+     */
+    @Test(dataProvider = "connectorClasses")
+    public void connectorClassesResolveAndAreSourceConnectors(String connectorClass) throws Exception {
+        Class<?> resolved = Class.forName(connectorClass);
+        Assert.assertTrue(SourceConnector.class.isAssignableFrom(resolved),
+                connectorClass + " is no longer a Kafka Connect SourceConnector");
+    }
+
+    @DataProvider(name = "jdbcUrls")
+    public Object[][] jdbcUrls() {
+        // The final column is the set of emitted keys the connector does not recognise. database.server.id is a
+        // MySQL binlog setting that getConfigMap emits unconditionally; Debezium 2.x ignores it everywhere else.
+        return new Object[][]{
+                {"jdbc:mysql://localhost:3306/SimpleDB", CDCSourceConstants.MYSQL_CONNECTOR_CLASS, "",
+                        Collections.emptyList()},
+                {"jdbc:postgresql://localhost:5432/SimpleDB", CDCSourceConstants.POSTGRESQL_CONNECTOR_CLASS, "",
+                        Collections.singletonList(CDCSourceConstants.DATABASE_SERVER_ID)},
+                {"jdbc:sqlserver://localhost:1433;databaseName=SimpleDB",
+                        CDCSourceConstants.SQLSERVER_CONNECTOR_CLASS, "",
+                        Collections.singletonList(CDCSourceConstants.DATABASE_SERVER_ID)},
+                {"jdbc:oracle:thin:@localhost:1521/XE", CDCSourceConstants.ORACLE_CONNECTOR_CLASS,
+                        CDCSourceConstants.ORACLE_OUTSERVER_PROPERTY_NAME + "=dbzxout",
+                        Collections.singletonList(CDCSourceConstants.DATABASE_SERVER_ID)},
+                {"jdbc:mongodb://rs0/localhost:27017/SimpleDB", CDCSourceConstants.MONGODB_CONNECTOR_CLASS, "",
+                        Collections.singletonList(CDCSourceConstants.DATABASE_SERVER_ID)}
+        };
+    }
+
+    /**
+     * Pins which keys {@code getConfigMap} emits that the target connector does not understand. Debezium drops
+     * unknown properties without complaint, so a key renamed or removed by an upgrade shows up here as a new entry,
+     * and a key that starts being recognised shows up as a missing one.
+     * <p>
+     * The expectation is not empty today: {@code database.server.id} is emitted to every connector even though only
+     * the MySQL binlog connector defines it. That is harmless on Debezium 2.x but worth revisiting on an upgrade that
+     * validates configuration more strictly.
+     */
+    @Test(dataProvider = "jdbcUrls")
+    public void emittedKeysTheConnectorIgnoresAreThoseExpected(String url, String connectorClass,
+                                                               String connectorProperties,
+                                                               List<String> expectedUnrecognised) throws Exception {
+        Map<String, Object> configMap = CDCSourceUtil.getConfigMap("user", "pass", url, "login",
+                HISTORY_FILE_DIRECTORY, SIDDHI_APP_NAME, STREAM_NAME, 5555, "", connectorProperties, 1234, null,
+                CDCSourceConstants.DECORDERBUFS_PLUGIN);
+
+        Assert.assertEquals(configMap.get(CDCSourceConstants.CONNECTOR_CLASS), connectorClass);
+
+        SourceConnector connector = (SourceConnector) Class.forName(connectorClass)
+                .getDeclaredConstructor().newInstance();
+        Set<String> knownKeys = connector.config().configKeys().keySet();
+
+        List<String> unrecognised = new ArrayList<>();
+        for (String key : configMap.keySet()) {
+            if (!NON_CONNECTOR_KEYS.contains(key) && !knownKeys.contains(key)) {
+                unrecognised.add(key);
+            }
+        }
+        Collections.sort(unrecognised);
+        List<String> expected = new ArrayList<>(expectedUnrecognised);
+        Collections.sort(expected);
+
+        Assert.assertEquals(unrecognised, expected,
+                "Change in the keys emitted for " + url + " that " + connectorClass + " does not recognise, and "
+                        + "which Debezium will therefore silently ignore");
+    }
+
+    /**
+     * Documents that the schema history settings are emitted even to MongoDB, which keeps no relational schema
+     * history. Unlike {@code database.server.id} these are storage level keys, so they never appear in a connector
+     * {@code ConfigDef} and are not covered by {@link #emittedKeysTheConnectorIgnoresAreThoseExpected}.
+     */
+    @Test
+    public void schemaHistoryKeysAreStillEmittedForMongoDb() throws WrongConfigurationException {
+        Map<String, Object> configMap = CDCSourceUtil.getConfigMap("user", "pass",
+                "jdbc:mongodb://rs0/localhost:27017/SimpleDB", "login", HISTORY_FILE_DIRECTORY, SIDDHI_APP_NAME,
+                STREAM_NAME, 5555, "", "", 1234, null, CDCSourceConstants.DECORDERBUFS_PLUGIN);
+
+        Assert.assertTrue(configMap.containsKey(CDCSourceConstants.DATABASE_HISTORY));
+        Assert.assertTrue(configMap.containsKey(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME));
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/QueryConfigurationTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/QueryConfigurationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.util;
+
+import io.siddhi.extension.io.cdc.source.config.Database;
+import io.siddhi.extension.io.cdc.source.config.QueryConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests the loading of {@code query-config.yaml}, which supplies the vendor specific select query used by polling
+ * mode. Reproduces the exact SnakeYAML wiring {@code PollingStrategy} uses, so that a SnakeYAML upgrade which changes
+ * the {@code Constructor} contract or tightens tag handling is caught here rather than at runtime.
+ */
+public class QueryConfigurationTest {
+
+    private static final String SELECT_QUERY_CONFIG_FILE = "query-config.yaml";
+    private static final String EXPECTED_QUERY = "SELECT {{COLUMN_LIST}} FROM {{TABLE_NAME}} {{CONDITION}}";
+
+    private QueryConfiguration loadQueryConfiguration() throws Exception {
+        MyYamlConstructor constructor = new MyYamlConstructor(QueryConfiguration.class);
+        TypeDescription queryTypeDescription = new TypeDescription(QueryConfiguration.class);
+        queryTypeDescription.putListPropertyType("databases", Database.class);
+        constructor.addTypeDescription(queryTypeDescription);
+        Yaml yaml = new Yaml(constructor);
+        try (InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream(SELECT_QUERY_CONFIG_FILE)) {
+            Assert.assertNotNull(inputStream, SELECT_QUERY_CONFIG_FILE + " is not on the test classpath");
+            return (QueryConfiguration) yaml.load(inputStream);
+        }
+    }
+
+    @Test
+    public void queryConfigurationLoadsEveryConfiguredDatabase() throws Exception {
+        QueryConfiguration queryConfiguration = loadQueryConfiguration();
+
+        Assert.assertNotNull(queryConfiguration);
+        Assert.assertNotNull(queryConfiguration.getDatabases());
+
+        List<String> names = new ArrayList<>();
+        for (Database database : queryConfiguration.getDatabases()) {
+            names.add(database.getName());
+        }
+        Assert.assertEquals(names,
+                Arrays.asList("mysql", "oracle", "PostgreSQL", "H2", "Microsoft SQL Server"));
+    }
+
+    /**
+     * The names are matched against {@code DatabaseMetaData.getDatabaseProductName()} case insensitively, and every
+     * vendor currently shares the same query template.
+     */
+    @Test
+    public void everyConfiguredDatabaseHasTheExpectedSelectQuery() throws Exception {
+        for (Database database : loadQueryConfiguration().getDatabases()) {
+            Assert.assertEquals(database.getSelectQuery(), EXPECTED_QUERY,
+                    "Unexpected select query for " + database.getName());
+        }
+    }
+
+    /**
+     * The constructor deliberately refuses classes outside the configuration model, so that a crafted tag in the yaml
+     * cannot instantiate arbitrary types.
+     */
+    @Test(expectedExceptions = org.yaml.snakeyaml.error.YAMLException.class)
+    public void unknownClassTagsAreRejected() {
+        MyYamlConstructor constructor = new MyYamlConstructor(QueryConfiguration.class);
+        Yaml yaml = new Yaml(constructor);
+        yaml.load("!!java.util.Random {}");
+    }
+}

--- a/component/src/test/resources/testng-suit1.xml
+++ b/component/src/test/resources/testng-suit1.xml
@@ -27,6 +27,11 @@
         <classes>
             <class name="io.siddhi.extension.io.cdc.source.TestCaseOfCDCSourceValidation"/>
             <class name="io.siddhi.extension.io.cdc.source.TestCaseOfCDCPollingMode"/>
+            <class name="io.siddhi.extension.io.cdc.util.CDCSourceUtilTest"/>
+            <class name="io.siddhi.extension.io.cdc.util.CDCPollingUtilTest"/>
+            <class name="io.siddhi.extension.io.cdc.util.QueryConfigurationTest"/>
+            <class name="io.siddhi.extension.io.cdc.util.DebeziumConfigContractTest"/>
+            <class name="io.siddhi.extension.io.cdc.source.listening.RdbmsChangeDataCaptureTest"/>
             <class name="io.siddhi.extension.io.cdc.source.listening.MongoChangeDataCaptureTest"/>
         </classes>
     </test>


### PR DESCRIPTION
## Purpose
The extension pins around 30 Debezium and Kafka Connect configuration keys, change event
field names and connector class names as string literals. Debezium silently ignores
configuration properties it does not recognise, so when an upgrade renames one of these,
the result is a source that starts up, logs nothing and emits no events. Nothing in the
existing test suite can detect that — as PR #98 showed, the MongoDB `patch` to
`updateDescription` rename went unnoticed through an entire Debezium major upgrade.

With a dependency and SpotBugs upgrade planned, we need a regression net that can be run
before and after the upgrade to tell a real behaviour change apart from an environmental
one. The existing suite is too thin to serve that purpose: 25 tests, 40.0% line coverage,
and the two classes most exposed to an upgrade sit at 2.3% and 18.4%.

Writing the tests surfaced one defect in polling mode, fixed here as well: the record
select query has no `ORDER BY`, so rows returned out of polling column order drag
`lastReadPollingColumnValue` backwards and cause records to be emitted twice.

Related to #98.

## Goals
- Detect renamed or removed Debezium/Kafka Connect configuration keys at build time rather
  than at runtime in a silent-failure mode.
- Cover the change event to Siddhi event translation for every operation and value type.
- Give the planned upgrade a fast, deterministic before/after comparison that needs no
  database and no containers.
- Stop polling mode emitting duplicate events when rows are not physically stored in
  polling column order.

## Approach
Five new test classes, all database free, all running under `mvn test` in `testng-suit1`:

- **`DebeziumConfigContractTest`** — asserts every hardcoded configuration key, change
  event field name, operation code and connector class against the constant the library
  itself publishes (`RelationalDatabaseConnectorConfig`, `CommonConnectorConfig`,
  `EmbeddedEngineConfig`, `FileSchemaHistory`, `MongoDbConnectorConfig`, `Envelope`), then
  validates the map `getConfigMap` produces against each connector's own `ConfigDef`. This
  is the check that would have caught the rename fixed in #98.
- **`CDCSourceUtilTest`** — asserts the complete configuration map produced for MySQL,
  PostgreSQL, SQL Server, Oracle and MongoDB, plus URL parsing failures,
  `connector.properties` parsing and server id generation.
- **`RdbmsChangeDataCaptureTest`** — change event translation for insert, update and
  delete, multi-operation mode with its `before_` prefixes and padded type defaults, and
  the `VariableScaleDecimal` / `Short` / `Byte` conversions. Events are built through
  Debezium's own `Envelope` builder rather than hand written schemas, so a reshaped
  envelope fails here.
- **`CDCPollingUtilTest`** and **`QueryConfigurationTest`** — polling mode
  `pool.properties` parsing, and the SnakeYAML wiring for `query-config.yaml` (relevant
  because SnakeYAML is itself in scope for the upgrade).

Two pre-existing deviations are **pinned by tests rather than fixed**, so that the upcoming
upgrade diff stays free of unrelated edits. Both are documented in the tests:

1. `getConfigMap` emits `database.server.id` to every connector, although only the MySQL
   binlog connector defines it. Harmless on Debezium 2.x, which ignores unknown properties,
   but worth revisiting on an upgrade that validates configuration more strictly.
2. The SID form of an Oracle URL (`jdbc:oracle:thin:@host:port:SID`) leaves
   `database.dbname` empty, because the URL pattern only recognises a SID introduced by a
   slash.

### Polling mode duplicate event fix
`ORDER BY <pollingColumn>` added to the record select query in both
`WaitOnMissingRecordPollingStrategy` and `DefaultPollingStrategy`. Both build the same
condition and both had the same defect. With the rows ascending,
`lastReadPollingColumnValue` can only move forward, so the duplicate cannot occur. This
also repairs the gap detection in the wait strategy, which compares each row against the
previous one and so is only meaningful on an ascending stream — previously it re-tripped on
the higher row every pass and never recognised the record it was waiting for, holding
records for the full `missed.record.waiting.timeout` and then releasing them out of order.

`testOutOfOrderRecords` asserted only the event count, immediately after
`SiddhiTestHelper.waitForEvents` returned, which races the poll that emits the duplicate. It
now records the ids as they arrive, waits three polling intervals to settle, and asserts the
exact sequence `[1, 2, 3, 4]`.

Note for reviewers: `{{CONDITION}}` is substituted at the end of the query template, so the
`ORDER BY` clause lands correctly for all five built-in templates in `query-config.yaml`. A
deployment that overrides `recordSelectQuery` through a system parameter and places
`{{CONDITION}}` somewhere other than the tail would get a malformed query.

## User stories
As a user of CDC polling mode, I want each row delivered exactly once and in order, even
when rows are committed out of sequence.

## Release note
Fixed duplicate events in CDC polling mode when table rows are not stored in polling column
order, and fixed `wait.on.missed.record` waiting for the full timeout instead of resuming
when the missing record arrives.

## Documentation
N/A — no configuration or documented behaviour changes; the fix brings the implementation in
line with the documented behaviour of `wait.on.missed.record`.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests

  58 new tests across 5 classes. Suite grows from 25 to 83.

  | Metric | Before | After |
  |---|---|---|
  | Line | 40.0% | **57.4%** |
  | Branch | 31.9% | **50.1%** |
  | Instruction | 34.4% | **54.1%** |

  Concentrated on the classes most exposed to a dependency upgrade:

  | Class | Before | After |
  |---|---|---|
  | `RdbmsChangeDataCapture` | 2.3% | **98.5%** |
  | `CDCSourceUtil` | 18.4% | **89.0%** |
  | `CDCPollingUtil` | 38.5% | **66.7%** |

  Known gaps, not addressed here: `InMemoryOffsetBackingStore` and the metrics classes
  remain at 0%, and `ChangeDataCapture` at 27.7%, since engine creation is only reachable
  through the MySQL integration profile.

- Integration tests

  No new integration tests; the existing `-Plocal-mysql` profile is unchanged.
  `testOutOfOrderRecords` was strengthened as described above, and verified as a real
  oracle: with the old count-only assertion it passed 3 runs in 4 because the duplicate
  usually landed after `shutdown()`; with the sequence assertion it fails every run without
  the fix (`expected [4] but found [5]`) and passes with it.

  Full suite: 83 tests, 0 failures on JDK 17, and on JDK 21 across two runs.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — the pinned SpotBugs 4.1.4 cannot
  read Java 17 or Java 21 class files (`Unsupported class file major version 61` / `65`), so
  the plugin cannot run on any supported JDK. Builds were verified with
  `-Dspotbugs.skip=true`. Upgrading SpotBugs is a follow-up PR in this series. Note that
  `SQL_INJECTION_JDBC` is already excluded for both strategy classes in
  `findbugs-exclude.xml`; the polling column was already interpolated into the `WHERE`
  clause and this change interpolates the same value into `ORDER BY`, so the exposure is
  unchanged.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
  — test credentials are literals such as `myuser` / `mypassword` against non-existent hosts.

## Samples
N/A

## Related PRs
- #98 — fixes MongoDB listening mode for the Debezium 2.x change event format. This PR
  generalises the guard that would have caught that bug.

## Migrations (if applicable)
N/A — no state or schema changes. Deployments overriding `recordSelectQuery` should confirm
`{{CONDITION}}` is the final element of their template.

## Test environment
- JDK: Temurin 17.0.12 and Temurin 21.0.5 (SI 4.4.0 targets JDK 21)
- OS: macOS (Darwin 25.0.0), arm64
- Maven 3.9.9
- Database: H2 2.1.210 for the polling tests; the new tests require no database
- Command: `mvn clean test -Dspotbugs.skip=true`

## Learning
Debezium publishes every configuration key as a `Field` constant and every connector exposes
a Kafka Connect `ConfigDef`, which makes it possible to assert our hardcoded strings against
the library's own definitions instead of duplicating them in test fixtures. The same applies
to change events: `io.debezium.data.Envelope` and `MongoDbSchemaFactory` build the real
schemas, so tests constructed from them fail when the event shape changes rather than when
someone forgets to update a fixture.

The polling defect was first seen as a single intermittent failure on JDK 21 that looked
like a JDK regression. It was not: the duplicate is produced on every run on both JDKs, and
the test only passed because `shutdown()` normally beat the next poll by about a second.
Asserting the received sequence after a settle period, rather than a count at the earliest
opportunity, exposed it immediately.

## Related Issues
- https://github.com/wso2-enterprise/wso2-integration-internal/issues/5254