### PR TITLE
Bump spotbugs version to compile with JDK 21

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/MongoChangeDataCapture.java
@@ -50,11 +50,14 @@ public class MongoChangeDataCapture extends ChangeDataCapture {
         //Map to return
         Map<String, Object> detailsMap = new HashMap<>();
         Struct record = (Struct) connectRecord.value();
+        if (record == null) {
+            return detailsMap;
+        }
         //get the change data object's operation.
         String op;
         try {
             op = (String) record.get(CDCSourceConstants.CONNECT_RECORD_OPERATION);
-        } catch (NullPointerException | DataException ex) {
+        } catch (DataException ex) {
             return detailsMap;
         }
         if (op == null) {

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/listening/RdbmsChangeDataCapture.java
@@ -51,11 +51,14 @@ public class RdbmsChangeDataCapture extends ChangeDataCapture {
         Map<String, Object> detailsMap = new HashMap<>();
         List<Object> transportProperties = new ArrayList();
         Struct record = (Struct) connectRecord.value();
+        if (record == null) {
+            return detailsMap;
+        }
         //get the change data object's operation.
         String op;
         try {
             op = (String) record.get(CDCSourceConstants.CONNECT_RECORD_OPERATION);
-        } catch (NullPointerException | DataException ex) {
+        } catch (DataException ex) {
             return detailsMap;
         }
         //match the change data's operation with user specifying operation and proceed.

--- a/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/CDCPoller.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/source/polling/CDCPoller.java
@@ -61,7 +61,6 @@ public class CDCPoller implements Runnable {
     private String poolPropertyString;
     private String jndiResource;
     private boolean isLocalDataSource = false;
-    private String appName;
     private String streamName;
 
     private PollingStrategy pollingStrategy;
@@ -81,7 +80,6 @@ public class CDCPoller implements Runnable {
         this.poolPropertyString = poolPropertyString;
         this.datasourceName = datasourceName;
         this.jndiResource = jndiResource;
-        this.appName = appName;
         this.streamName = sourceEventListener.getStreamDefinition().getId();
         this.cronConfiguration = cronConfiguration;
 

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -33,6 +33,8 @@ import java.util.regex.Pattern;
  * This class contains Util methods for the CDCSource.
  */
 public class CDCSourceUtil {
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     public static Map<String, Object> getConfigMap(String username, String password, String url, String tableName,
                                                    String historyFileDirectory, String siddhiAppName,
                                                    String siddhiStreamName, int serverID, String serverName,
@@ -226,8 +228,7 @@ public class CDCSourceUtil {
             }
 
             if (serverID == CDCSourceConstants.DEFAULT_SERVER_ID) {
-                SecureRandom random = new SecureRandom();
-                configMap.put(CDCSourceConstants.DATABASE_SERVER_ID, random.nextInt(1001) + 5400);
+                configMap.put(CDCSourceConstants.DATABASE_SERVER_ID, RANDOM.nextInt(1001) + 5400);
             } else {
                 configMap.put(CDCSourceConstants.DATABASE_SERVER_ID, serverID);
             }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -46,4 +46,44 @@
         <Class name="io.siddhi.extension.io.cdc.source.polling.strategies.WaitOnMissingRecordPollingStrategy" />
         <Bug pattern="SQL_INJECTION_JDBC" />
     </Match>
+    <!-- EI_EXPOSE_REP / MS_EXPOSE_REP: the objects held here are collaborators that are deliberately shared,
+         not defensive-copy candidates. Copying a HikariDataSource, a Quartz Scheduler, the metrics registry,
+         the CDCSource offset map or the CDCSourceObjectKeeper singleton would break the behaviour that
+         depends on them being the same instance. Reported since SpotBugs enabled these by default. -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Bug pattern="MS_EXPOSE_REP"/>
+    </Match>
+
+    <!-- AT_*: flagged on counters and flags written by the polling thread. Real but low impact, and making
+         them correct means reworking how the polling loop publishes its state. Tracked separately rather
+         than folded into a toolchain upgrade. -->
+    <Match>
+        <Class name="io.siddhi.extension.io.cdc.source.polling.CDCPoller"/>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="io.siddhi.extension.io.cdc.source.polling.strategies.DefaultPollingStrategy"/>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+    <Match>
+        <Class name="io.siddhi.extension.io.cdc.source.polling.strategies.DefaultPollingStrategy"/>
+        <Bug pattern="AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"/>
+    </Match>
+    <Match>
+        <Class name="io.siddhi.extension.io.cdc.source.metrics.PollingMetrics"/>
+        <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+    </Match>
+
+    <!-- CT_CONSTRUCTOR_THROW: guards against finalizer attacks; this class declares no finalizer and
+         failing the constructor is the intended behaviour when the datasource cannot be initialised. -->
+    <Match>
+        <Class name="io.siddhi.extension.io.cdc.source.polling.CDCPoller"/>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs.maven.plugin.version}</version>
                 <configuration>
                     <excludeFilterFile>${maven.findbugsplugin.version.exclude}</excludeFilterFile>
                 </configuration>
@@ -316,6 +317,7 @@
         <carbon.transport.version>4.4.15</carbon.transport.version>
         <siddhi-map-keyvalue.version>2.1.2</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
+        <spotbugs.maven.plugin.version>4.9.3.1</spotbugs.maven.plugin.version>
         <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
         <debezium-connector-mysql.version>2.7.3.Final</debezium-connector-mysql.version>
         <debezium-embedded.version>2.7.3.Final</debezium-embedded.version>


### PR DESCRIPTION
## Purpose
The SpotBugs version inherited from the `org.wso2:wso2:5.3` parent is 4.1.4, which cannot
read class files newer than Java 11. The build therefore fails during analysis, before any
findings are produced:

```
java.lang.IllegalArgumentException: Unsupported class file major version 61   (JDK 17)
java.lang.IllegalArgumentException: Unsupported class file major version 65   (JDK 21)
```

This means static analysis has effectively not run on this repository for some time, and
every build has to be invoked with `-Dspotbugs.skip=true` to get past it. WSO2 Integrator:
SI 4.4.0 requires JDK 21, so the problem cannot be avoided by staying on an older JDK.

This is the first step of a wider dependency upgrade; the Kafka Connect upgrade follows
separately.

## Goals
- Get static analysis running again on the JDKs this extension is actually built with.
- Remove the need for `-Dspotbugs.skip=true`.
- Resolve the findings the newer SpotBugs reports, either by fixing them or by recording an
  explicit, justified suppression.

## Approach
Pinned `spotbugs-maven-plugin` to 4.9.3.1 in the root POM, overriding the parent's 4.1.4, via
a new `spotbugs.maven.plugin.version` property.

The upgrade reported 20 findings, all from detectors introduced since 4.1.4. Three were
fixed and 17 suppressed.

### Fixed

| Finding | Change |
|---|---|
| `DMI_RANDOM_USED_ONLY_ONCE` (High) | `CDCSourceUtil.getConfigMap` constructed a `SecureRandom` on every call and used it once, to generate a default `database.server.id`. Hoisted to a `static final` field. Covered by the existing `CDCSourceUtilTest.defaultServerIdIsRandomisedWithinTheExpectedRange`. |
| `URF_UNREAD_FIELD` | `CDCPoller.appName` was assigned in the constructor but never read — all three usages reference the constructor parameter, not the field. Field and assignment removed. |
| `DCN_NULLPOINTER_EXCEPTION` (2 sites) | `RdbmsChangeDataCapture.createMap` and `MongoChangeDataCapture.createMap` caught `NullPointerException` to guard against a null change event value. Replaced with an explicit `record == null` check, leaving only `DataException` caught. Behaviour is unchanged. |

### Suppressed

| Family | Count | Justification |
|---|---|---|
| `EI_EXPOSE_REP`, `EI_EXPOSE_REP2`, `MS_EXPOSE_REP` | 11 | The objects involved are collaborators that are deliberately shared, not defensive-copy candidates: a `HikariDataSource`, a Quartz `Scheduler`, the metrics registry, the `CDCSource` offset map used for state persistence, and the `CDCSourceObjectKeeper` singleton. Copying any of them would break behaviour that depends on the same instance being used. SpotBugs enabled this family much more aggressively after 4.1.4. There is existing precedent in `findbugs-exclude.xml`, which already excluded it for `QueryConfiguration`. |
| `AT_STALE_THREAD_WRITE_OF_PRIMITIVE`, `AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE` | 5 | Counters and flags written by the polling thread (`eventsPerPollingInterval`, `isLocalDataSource`, `pollingHistorySize`). The concern is legitimate but low impact, and addressing it properly means reworking how the polling loop publishes its state — not something to fold into a toolchain upgrade. Suppressed per class rather than globally, so new occurrences elsewhere still surface. |
| `CT_CONSTRUCTOR_THROW` | 1 | Guards against finalizer attacks. `CDCPoller` declares no finalizer, and failing the constructor is the intended behaviour when the datasource cannot be initialised. |

Two notes on the suppression style:

- The new entries use **one `<Bug pattern>` per `<Match>`**. The pre-existing entries use
  comma-separated lists, one of which spans a line break
  (`SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING,\n FORMAT_STRING_MANIPULATION`).
  Those were verified to still be honoured under 4.9.3.1 — neither pattern reappeared in the
  findings — but the single-pattern form avoids relying on that.
- 20 findings, 3 fixed and 17 suppressed, accounts for the whole set. The resulting
  `BugInstance size is 0` is a real clean run, not analysis silently failing to start.

## User stories
N/A — build tooling change with no runtime behaviour change.

## Release note
N/A — no functional change.

## Documentation
N/A — no user facing behaviour or configuration changes.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests

  No new tests. The existing suite of 83 tests passes unchanged; coverage is unaffected
  (line 57.4%, branch 50.1%). The three code fixes are covered by existing tests:
  `CDCSourceUtilTest` exercises the `SecureRandom` path, and `RdbmsChangeDataCaptureTest`
  and `MongoChangeDataCaptureTest` both cover change events without a usable operation
  field.

- Integration tests

  None added; the `-Plocal-mysql` profile is unchanged.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **partially** — SpotBugs itself now runs
  clean on both JDK 17 and JDK 21, which it could not do at all before this change. The
  FindSecurityBugs plugin is not configured as a SpotBugs plugin dependency in this build,
  so its detectors do not execute; the `SQL_INJECTION_JDBC`, `PATH_TRAVERSAL_IN` and
  `IMPROPER_UNICODE` entries already present in `findbugs-exclude.xml` are consequently
  inert. Wiring it in is worth a follow-up, but is out of scope here — this PR restores the
  core analysis that was completely broken.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
- #99 — regression tests and the polling mode duplicate event fix. Merged; this PR builds on it.
- #98 — MongoDB listening mode fix for the Debezium 2.x change event format.
- Kafka Connect 4.x upgrade to follow in a separate PR.

## Migrations (if applicable)
N/A

## Test environment
- JDK: Temurin 17.0.12 and Temurin 21.0.5 (SI 4.4.0 targets JDK 21)
- OS: macOS (Darwin 25.0.0), arm64
- Maven 3.9.9
- Command: `mvn clean install` — note the absence of `-Dspotbugs.skip=true`, which was
  previously required. Verified green on both JDKs: `BugInstance size is 0`, 83 tests,
  0 failures, packaging (shade and OSGi bundle) successful.

## Learning
The parent POM pins the plugin version, so the override has to be an explicit `<version>` on
the plugin declaration in this repository's root POM rather than a property the parent
already reads. Worth knowing that a stale analysis plugin fails loudly on a new JDK rather
than degrading quietly — but because the failure is a build error rather than a finding, the
usual reaction is to add a skip flag, and the analysis then stays off indefinitely.

## Related Issues
- https://github.com/wso2-enterprise/wso2-integration-internal/issues/5254
