### PR TITLE
Bump kafka-connect to 4.3.1 and Debezium to 3.6.1

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -87,13 +87,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.siddhi.extension.map.keyvalue</groupId>
-            <artifactId>siddhi-map-keyvalue</artifactId>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.shyiko</groupId>
-            <artifactId>mysql-binlog-connector-java</artifactId>
+            <groupId>io.siddhi.extension.map.keyvalue</groupId>
+            <artifactId>siddhi-map-keyvalue</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.siddhi.extension.store.rdbms</groupId>
@@ -653,14 +655,18 @@
                                     <include>org.apache.kafka:connect-json</include>
                                     <include>org.apache.kafka:connect-runtime</include>
                                     <include>org.apache.kafka:kafka-clients</include>
-                                    <include>com.github.shyiko:mysql-binlog-connector-java</include>
+                                    <include>org.apache.maven:maven-artifact</include>
+                                    <include>org.codehaus.plexus:plexus-utils</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.json:json</include>
+                                    <include>com.datadoghq:sketches-java</include>
+                                    <include>com.github.luben:zstd-jni</include>
                                     <include>com.fasterxml.jackson.core:jackson-core</include>
                                     <include>com.fasterxml.jackson.core:jackson-databind</include>
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
                                     <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+                                    <include>com.fasterxml.jackson.module:jackson-module-blackbird</include>
                                     <include>com.mysql:mysql-connector-j</include>
                                 </includes>
                             </artifactSet>
@@ -686,11 +692,15 @@
                                 </filter>
                                 <filter>
                                     <artifact>*:*</artifact>
+                                    <!-- META-INF/MANIFEST.MF is deliberately NOT excluded here. This filter
+                                         matches the project artifact too, so excluding it discards the OSGi
+                                         manifest maven-bundle-plugin generates, and the result is rejected as
+                                         an invalid bundle. Shade keeps the main artifact's manifest and drops
+                                         dependency manifests on its own. -->
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
-                                        <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>META-INF/versions/**</exclude>
                                         <exclude>org/slf4j/impl/**</exclude>
                                         <exclude>**/StaticLoggerBinder.class</exclude>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -82,6 +82,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.siddhi.extension.map.keyvalue</groupId>
             <artifactId>siddhi-map-keyvalue</artifactId>
             <scope>test</scope>
@@ -632,7 +637,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -656,9 +661,6 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
                                     <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
-                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
-                                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
-                                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
                                     <include>com.mysql:mysql-connector-j</include>
                                 </includes>
                             </artifactSet>

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceConstants.java
@@ -48,6 +48,12 @@ public class CDCSourceConstants {
     public static final String DATABASE_USER = "database.user";
     public static final String DATABASE_PASSWORD = "database.password";
     public static final String OFFSET_STORAGE = "offset.storage";
+    public static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
+    public static final String BOOTSTRAP_SERVERS_PLACEHOLDER = "localhost:9092";
+    public static final String RECORD_PROCESSING_ORDER = "record.processing.order";
+    public static final String RECORD_PROCESSING_ORDER_ORDERED = "ORDERED";
+    public static final String RECORD_PROCESSING_THREADS = "record.processing.threads";
+    public static final String RECORD_PROCESSING_THREADS_SINGLE = "1";
     public static final String CDC_SOURCE_OBJECT = "cdc.source.object";
     public static final String DATABASE_HISTORY = "schema.history.internal";
     public static final String MYSQL_CONNECTOR_CLASS = "io.debezium.connector.mysql.MySqlConnector";

--- a/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/cdc/util/CDCSourceUtil.java
@@ -243,6 +243,19 @@ public class CDCSourceUtil {
             configMap.put(CDCSourceConstants.OFFSET_STORAGE, InMemoryOffsetBackingStore.class.getName());
             configMap.put(CDCSourceConstants.CDC_SOURCE_OBJECT, cdcSourceHashCode);
 
+            // Kafka Connect 4.x removed the default for bootstrap.servers, so WorkerConfig fails to
+            // build without it. The embedded engine never talks to a broker, which makes the value
+            // inert, but it has to be present.
+            configMap.put(CDCSourceConstants.BOOTSTRAP_SERVERS, CDCSourceConstants.BOOTSTRAP_SERVERS_PLACEHOLDER);
+
+            // Debezium 3.x delivers records through the async engine. These are its defaults, pinned
+            // explicitly because handleEvent is not thread safe and relies on being called serially
+            // and in order.
+            configMap.put(CDCSourceConstants.RECORD_PROCESSING_ORDER,
+                    CDCSourceConstants.RECORD_PROCESSING_ORDER_ORDERED);
+            configMap.put(CDCSourceConstants.RECORD_PROCESSING_THREADS,
+                    CDCSourceConstants.RECORD_PROCESSING_THREADS_SINGLE);
+
             //set history file path.
             configMap.put(CDCSourceConstants.DATABASE_HISTORY, CDCSourceConstants.DATABASE_HISTORY_FILEBASE_HISTORY);
             configMap.put(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME,

--- a/component/src/main/resources/META-INF/services/io.debezium.connector.base.QueueProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.connector.base.QueueProvider
@@ -1,0 +1,1 @@
+io.debezium.connector.base.DefaultQueueProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$BuilderFactory
+++ b/component/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$BuilderFactory
@@ -1,2 +1,1 @@
-io.debezium.embedded.ConvertingEngineBuilderFactory
 io.debezium.embedded.async.ConvertingAsyncEngineBuilderFactory

--- a/component/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.metadata.ComponentMetadataProvider
@@ -1,0 +1,7 @@
+io.debezium.transforms.metadata.TransformsMetadataProvider
+io.debezium.converters.metadata.ConverterMetadataProvider
+io.debezium.connector.mongodb.metadata.MongoDbMetadataProvider
+io.debezium.connector.mysql.metadata.MySqlMetadataProvider
+io.debezium.connector.oracle.metadata.OracleMetadataProvider
+io.debezium.connector.postgresql.metadata.PostgresMetadataProvider
+io.debezium.connector.sqlserver.metadata.SqlServerMetadataProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.metadata.ConnectorMetadataProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.metadata.ConnectorMetadataProvider
@@ -1,5 +1,0 @@
-io.debezium.connector.postgresql.metadata.PostgresConnectorMetadataProvider
-io.debezium.connector.mysql.metadata.MySqlConnectorMetadataProvider
-io.debezium.connector.sqlserver.metadata.SqlServerConnectorMetadataProvider
-io.debezium.connector.oracle.metadata.OracleConnectorMetadataProvider
-io.debezium.connector.mongodb.metadata.MongoDbConnectorMetadataProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.actions.SignalActionProvider
+++ b/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.actions.SignalActionProvider
@@ -1,1 +1,3 @@
 io.debezium.pipeline.signal.actions.StandardActionProvider
+io.debezium.connector.mysql.signal.MySqlSignalActionProvider
+io.debezium.connector.oracle.spi.OracleActionProvider

--- a/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.channels.SignalChannelReader
+++ b/component/src/main/resources/META-INF/services/io.debezium.pipeline.signal.channels.SignalChannelReader
@@ -2,3 +2,4 @@ io.debezium.pipeline.signal.channels.SourceSignalChannel
 io.debezium.pipeline.signal.channels.KafkaSignalChannel
 io.debezium.pipeline.signal.channels.FileSignalChannel
 io.debezium.pipeline.signal.channels.jmx.JmxSignalChannel
+io.debezium.pipeline.signal.channels.process.InProcessSignalChannel

--- a/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
+++ b/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotLock
@@ -9,3 +9,5 @@ io.debezium.connector.sqlserver.snapshot.lock.NoSnapshotLock
 io.debezium.connector.sqlserver.snapshot.lock.ExclusiveSnapshotLock
 io.debezium.connector.oracle.snapshot.lock.NoSnapshotLock
 io.debezium.connector.oracle.snapshot.lock.SharedSnapshotLock
+io.debezium.connector.binlog.snapshot.lock.MinimalAtLeastOnceSnapshotLock
+io.debezium.connector.mysql.snapshot.lock.MinimalPerconaNoTableLocksSnapshotLock

--- a/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
+++ b/component/src/main/resources/META-INF/services/io.debezium.snapshot.spi.SnapshotQuery
@@ -2,3 +2,4 @@ io.debezium.connector.postgresql.snapshot.query.SelectAllSnapshotQuery
 io.debezium.connector.mysql.snapshot.query.SelectAllSnapshotQuery
 io.debezium.connector.sqlserver.snapshot.query.SelectAllSnapshotQuery
 io.debezium.connector.oracle.snapshot.query.SelectAllSnapshotQuery
+io.debezium.connector.mongodb.snapshot.query.SelectAllSnapshotQuery

--- a/component/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
+++ b/component/src/main/resources/META-INF/services/io.debezium.spi.snapshot.Snapshotter
@@ -4,7 +4,5 @@ io.debezium.snapshot.mode.InitialOnlySnapshotter
 io.debezium.snapshot.mode.NoDataSnapshotter
 io.debezium.snapshot.mode.RecoverySnapshotter
 io.debezium.snapshot.mode.WhenNeededSnapshotter
-io.debezium.snapshot.mode.NeverSnapshotter
-io.debezium.snapshot.mode.SchemaOnlySnapshotter
-io.debezium.snapshot.mode.SchemaOnlyRecoverySnapshotter
 io.debezium.snapshot.mode.ConfigurationBasedSnapshotter
+io.debezium.snapshot.mode.WhenNeededNoDataSnapshotter

--- a/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/DebeziumEngineCompatibilityTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/source/listening/DebeziumEngineCompatibilityTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.cdc.source.listening;
+
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.siddhi.extension.io.cdc.source.CDCSource;
+import io.siddhi.extension.io.cdc.util.CDCSourceConstants;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Runs the real Debezium embedded engine end to end, with a synthetic connector in place of a database.
+ * <p>
+ * Every other test in this suite exercises translation and configuration logic only, and never starts the engine.
+ * That leaves the whole Kafka Connect runtime this extension depends on — {@code WorkerConfig}, the converters, the
+ * offset backing store, the commit policy, the transform chain — completely unexercised, which matters because
+ * Debezium is compiled against a different Kafka Connect minor line than the one we resolve at build time. A binary
+ * incompatibility there surfaces as a {@link LinkageError} the moment the engine is constructed or run, and this test
+ * is what turns that into a build failure instead of a runtime surprise.
+ * <p>
+ * {@code io.debezium.connector.simple.SimpleSourceConnector} ships in the debezium-embedded artifact and emits
+ * synthetic records, so no database or container is involved.
+ */
+public class DebeziumEngineCompatibilityTest {
+
+    private static final String SIMPLE_SOURCE_CONNECTOR = "io.debezium.connector.simple.SimpleSourceConnector";
+    private static final int RECORDS_PER_BATCH = 2;
+    private static final int BATCH_COUNT = 3;
+    private static final int EXPECTED_RECORDS = RECORDS_PER_BATCH * BATCH_COUNT;
+
+    /**
+     * Collects the records the engine delivers. Returning an empty map keeps
+     * {@code ChangeDataCapture.handleEvent} from going on to the source event listener, which a unit test has no
+     * way to supply.
+     */
+    private static final class RecordingChangeDataCapture extends ChangeDataCapture {
+        private final AtomicInteger records = new AtomicInteger();
+        private final CountDownLatch latch;
+
+        private RecordingChangeDataCapture(int expected) {
+            super(CDCSourceConstants.INSERT, null, null);
+            this.latch = new CountDownLatch(expected);
+        }
+
+        @Override
+        Map<String, Object> createMap(ConnectRecord connectRecord, String operation) {
+            records.incrementAndGet();
+            latch.countDown();
+            return new HashMap<>();
+        }
+    }
+
+    private Map<String, Object> engineConfig(int cdcSourceHashCode) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(CDCSourceConstants.CONNECTOR_NAME, "debezium-compatibility-test");
+        config.put(CDCSourceConstants.CONNECTOR_CLASS, SIMPLE_SOURCE_CONNECTOR);
+        config.put(CDCSourceConstants.OFFSET_STORAGE, InMemoryOffsetBackingStore.class.getName());
+        config.put(CDCSourceConstants.CDC_SOURCE_OBJECT, cdcSourceHashCode);
+        config.put("offset.flush.interval.ms", 1000);
+        // Kafka Connect 4.x made bootstrap.servers a required WorkerConfig property with no default.
+        // The embedded engine never talks to a broker, so the value is inert, but it must be present.
+        config.put("bootstrap.servers", "localhost:9092");
+        config.put("topic.name", "compatibility.topic");
+        config.put("record.count.per.batch", RECORDS_PER_BATCH);
+        config.put("batch.count", BATCH_COUNT);
+        return config;
+    }
+
+    /**
+     * Constructs the engine through {@link ChangeDataCapture#getEngine} — the production code path — and runs it.
+     */
+    @Test(timeOut = 90000)
+    public void embeddedEngineStartsAndDeliversRecords() throws Exception {
+        CDCSource cdcSource = new CDCSource();
+        CDCSourceObjectKeeper.getCdcSourceObjectKeeper().addCdcObject(cdcSource);
+        RecordingChangeDataCapture capture = new RecordingChangeDataCapture(EXPECTED_RECORDS);
+        capture.setConfig(engineConfig(cdcSource.hashCode()));
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<String> failureMessage = new AtomicReference<>();
+        DebeziumEngine.CompletionCallback callback = (success, message, error) -> {
+            if (!success) {
+                failure.set(error);
+                failureMessage.set(message);
+            }
+        };
+
+        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = capture.getEngine(callback);
+        Assert.assertNotNull(engine, "Debezium engine could not be created");
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            executorService.execute(engine);
+            boolean delivered = capture.latch.await(45, TimeUnit.SECONDS);
+
+            assertNoLinkageError(failure.get(), failureMessage.get());
+            Assert.assertTrue(delivered, "Engine delivered only " + capture.records.get() + " of "
+                    + EXPECTED_RECORDS + " records. Engine message: " + failureMessage.get()
+                    + ", error: " + failure.get());
+        } finally {
+            closeWithoutWaiting(engine);
+            executorService.shutdownNow();
+            CDCSourceObjectKeeper.getCdcSourceObjectKeeper().removeObject(cdcSource.hashCode());
+        }
+
+        assertNoLinkageError(failure.get(), failureMessage.get());
+    }
+
+    /**
+     * The engine writes offsets through {@link InMemoryOffsetBackingStore}, which extends a Kafka Connect class and
+     * is otherwise never instantiated by any test. Reaching the point where offsets are handed back to the
+     * {@link CDCSource} proves the whole store contract still binds.
+     */
+    @Test(timeOut = 90000)
+    public void offsetsAreHandedBackToTheSource() throws Exception {
+        CDCSource cdcSource = new CDCSource();
+        CDCSourceObjectKeeper.getCdcSourceObjectKeeper().addCdcObject(cdcSource);
+        RecordingChangeDataCapture capture = new RecordingChangeDataCapture(EXPECTED_RECORDS);
+        capture.setConfig(engineConfig(cdcSource.hashCode()));
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<String> failureMessage = new AtomicReference<>();
+        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = capture.getEngine(
+                (success, message, error) -> {
+                    if (!success) {
+                        failure.set(error);
+                        failureMessage.set(message);
+                    }
+                });
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            executorService.execute(engine);
+            capture.latch.await(45, TimeUnit.SECONDS);
+            assertNoLinkageError(failure.get(), failureMessage.get());
+            Assert.assertNotNull(cdcSource.getOffsetData(),
+                    "No offsets reached the CDCSource, so the offset backing store never completed a save");
+        } finally {
+            closeWithoutWaiting(engine);
+            executorService.shutdownNow();
+            CDCSourceObjectKeeper.getCdcSourceObjectKeeper().removeObject(cdcSource.hashCode());
+        }
+    }
+
+    /**
+     * {@code DebeziumEngine.close()} waits up to five minutes for the connector to stop, which exceeds any sensible
+     * test timeout and would mask the assertion result.
+     */
+    private void closeWithoutWaiting(DebeziumEngine<?> engine) {
+        Thread closer = new Thread(() -> {
+            try {
+                engine.close();
+            } catch (Exception ignored) {
+                // shutting down; nothing useful to do here
+            }
+        });
+        closer.setDaemon(true);
+        closer.start();
+    }
+
+    /**
+     * A {@link LinkageError} here means Debezium and the resolved Kafka Connect version are binary incompatible,
+     * which is a different and far more serious problem than the engine failing to start for a configuration reason.
+     */
+    private void assertNoLinkageError(Throwable error, String message) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof LinkageError) {
+                Assert.fail("Debezium is binary incompatible with the resolved Kafka Connect version. "
+                        + t.getClass().getName() + ": " + t.getMessage() + " (engine message: " + message + ")");
+            }
+        }
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCSourceUtilTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/CDCSourceUtilTest.java
@@ -59,6 +59,10 @@ public class CDCSourceUtilTest {
         expected.put(CDCSourceConstants.DATABASE_SERVER_NAME, expectedTopicPrefix);
         expected.put(CDCSourceConstants.OFFSET_STORAGE, InMemoryOffsetBackingStore.class.getName());
         expected.put(CDCSourceConstants.CDC_SOURCE_OBJECT, SOURCE_HASH_CODE);
+        expected.put(CDCSourceConstants.BOOTSTRAP_SERVERS, CDCSourceConstants.BOOTSTRAP_SERVERS_PLACEHOLDER);
+        expected.put(CDCSourceConstants.RECORD_PROCESSING_ORDER, CDCSourceConstants.RECORD_PROCESSING_ORDER_ORDERED);
+        expected.put(CDCSourceConstants.RECORD_PROCESSING_THREADS,
+                CDCSourceConstants.RECORD_PROCESSING_THREADS_SINGLE);
         expected.put(CDCSourceConstants.DATABASE_HISTORY, CDCSourceConstants.DATABASE_HISTORY_FILEBASE_HISTORY);
         expected.put(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME, HISTORY_FILE_DIRECTORY + STREAM_NAME + ".dat");
         expected.put(CDCSourceConstants.CONNECTOR_NAME, SIDDHI_APP_NAME + STREAM_NAME);

--- a/component/src/test/java/io/siddhi/extension/io/cdc/util/DebeziumConfigContractTest.java
+++ b/component/src/test/java/io/siddhi/extension/io/cdc/util/DebeziumConfigContractTest.java
@@ -26,10 +26,12 @@ import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
 import io.debezium.data.Envelope;
 import io.debezium.embedded.EmbeddedEngineConfig;
+import io.debezium.embedded.async.AsyncEngineConfig;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.siddhi.extension.io.cdc.source.listening.WrongConfigurationException;
+import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -68,7 +70,10 @@ public class DebeziumConfigContractTest {
             CDCSourceConstants.OFFSET_STORAGE,
             CDCSourceConstants.DATABASE_HISTORY,
             CDCSourceConstants.DATABASE_HISTORY_FILE_NAME,
-            CDCSourceConstants.CDC_SOURCE_OBJECT));
+            CDCSourceConstants.CDC_SOURCE_OBJECT,
+            CDCSourceConstants.BOOTSTRAP_SERVERS,
+            CDCSourceConstants.RECORD_PROCESSING_ORDER,
+            CDCSourceConstants.RECORD_PROCESSING_THREADS));
 
     @Test
     public void connectorLevelKeysMatchDebeziumConstants() {
@@ -102,6 +107,23 @@ public class DebeziumConfigContractTest {
                 HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.name());
         Assert.assertEquals(CDCSourceConstants.DATABASE_HISTORY_FILE_NAME, FileSchemaHistory.FILE_PATH.name());
         Assert.assertEquals(CDCSourceConstants.DATABASE_HISTORY_FILEBASE_HISTORY, FileSchemaHistory.class.getName());
+        Assert.assertEquals(CDCSourceConstants.BOOTSTRAP_SERVERS, WorkerConfig.BOOTSTRAP_SERVERS_CONFIG);
+        Assert.assertEquals(CDCSourceConstants.RECORD_PROCESSING_ORDER,
+                AsyncEngineConfig.RECORD_PROCESSING_ORDER.name());
+        Assert.assertEquals(CDCSourceConstants.RECORD_PROCESSING_THREADS,
+                AsyncEngineConfig.RECORD_PROCESSING_THREADS.name());
+    }
+
+    /**
+     * The async engine is the only engine from Debezium 3.x on, and {@code handleEvent} depends on being called
+     * serially and in order. ORDERED is Debezium's own default, so what we emit is a pin rather than a change; this
+     * asserts that is still true, because a change of that default would silently make delivery concurrent.
+     */
+    @Test
+    public void orderedIsStillTheRecordProcessingDefault() {
+        Assert.assertEquals(AsyncEngineConfig.RECORD_PROCESSING_ORDER.defaultValueAsString(),
+                CDCSourceConstants.RECORD_PROCESSING_ORDER_ORDERED,
+                "Debezium changed the default record processing order, so pinning it is now a behaviour change");
     }
 
     @Test

--- a/component/src/test/resources/testng-suit1.xml
+++ b/component/src/test/resources/testng-suit1.xml
@@ -33,6 +33,7 @@
             <class name="io.siddhi.extension.io.cdc.util.DebeziumConfigContractTest"/>
             <class name="io.siddhi.extension.io.cdc.source.listening.RdbmsChangeDataCaptureTest"/>
             <class name="io.siddhi.extension.io.cdc.source.listening.MongoChangeDataCaptureTest"/>
+            <class name="io.siddhi.extension.io.cdc.source.listening.DebeziumEngineCompatibilityTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
                 <version>${org.testng.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <!--     Kafka client dependencies       -->
             <dependency>
@@ -246,6 +252,20 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Managed only to align the version. connect-file arrives transitively through
+                 debezium-embedded, which pins it to a 3.x release; without this the classpath ends up
+                 with a mixed Kafka Connect 4.x / 3.x set. -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-file</artifactId>
+                <version>${kafka.connect.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
@@ -264,6 +284,13 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <!-- Binds SLF4J to log4j 1.x. Its implementation (reload4j) used to reach this build
+                         transitively through Kafka Connect 3.x and is absent from 4.x, leaving the binding
+                         pointing at classes that no longer exist. -->
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -345,7 +372,7 @@
         <siddhi-cdc-postgres.port>5433</siddhi-cdc-postgres.port>
         <docker.container.siddhi-cdc-postgres.ip>0.0.0.0</docker.container.siddhi-cdc-postgres.ip>
         <oracle.jdbc.Driver.version>12.2.0.1</oracle.jdbc.Driver.version>
-        <kafka.connect.version>3.7.1</kafka.connect.version>
+        <kafka.connect.version>4.3.1</kafka.connect.version>
         <mongodb.connector.version>3.4.0</mongodb.connector.version>
         <json.version>20190722</json.version>
         <carbon.analytics.version>3.0.57</carbon.analytics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,19 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-embedded</artifactId>
+                <version>${debezium-embedded.version}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${hikari.version}</version>
@@ -129,11 +142,6 @@
                 <artifactId>siddhi-map-keyvalue</artifactId>
                 <version>${siddhi-map-keyvalue.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.github.shyiko</groupId>
-                <artifactId>mysql-binlog-connector-java</artifactId>
-                <version>${mysql-binlog-connector-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.siddhi.extension.store.rdbms</groupId>
@@ -266,6 +274,23 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- mysql-binlog-connector-java drags an old zstd-jni that wins on nearest-definition,
+                 but Kafka's compression classes are compiled against the newer one and are shaded
+                 into this artifact. Pinned forward to the version debezium-build-parent declares. -->
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${zstd.jni.version}</version>
+            </dependency>
+            <!-- debezium-connector-oracle pulls org.glassfish.jaxb:jaxb-runtime for its Ehcache
+                 LogMiner buffer. That artifact's parent pins javax.xml.bind:jaxb-api to a
+                 java.net-only build which is absent from Maven Central, so resolution fails
+                 without this pin. -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
@@ -345,13 +370,12 @@
         <siddhi-map-keyvalue.version>2.1.2</siddhi-map-keyvalue.version>
         <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <spotbugs.maven.plugin.version>4.9.3.1</spotbugs.maven.plugin.version>
-        <mysql-binlog-connector-java.version>0.13.0</mysql-binlog-connector-java.version>
-        <debezium-connector-mysql.version>2.7.3.Final</debezium-connector-mysql.version>
-        <debezium-embedded.version>2.7.3.Final</debezium-embedded.version>
-        <debezium-connector-oracle.version>2.7.3.Final</debezium-connector-oracle.version>
-        <debezium-connector-postgres.version>2.7.3.Final</debezium-connector-postgres.version>
-        <debezium-connector-sqlserver.version>2.7.3.Final</debezium-connector-sqlserver.version>
-        <debezium-connector-mongodb.version>2.7.3.Final</debezium-connector-mongodb.version>
+        <debezium-connector-mysql.version>3.6.1.Final</debezium-connector-mysql.version>
+        <debezium-embedded.version>3.6.1.Final</debezium-embedded.version>
+        <debezium-connector-oracle.version>3.6.1.Final</debezium-connector-oracle.version>
+        <debezium-connector-postgres.version>3.6.1.Final</debezium-connector-postgres.version>
+        <debezium-connector-sqlserver.version>3.6.1.Final</debezium-connector-sqlserver.version>
+        <debezium-connector-mongodb.version>3.6.1.Final</debezium-connector-mongodb.version>
         <version.oracle.driver>12.1.0.2</version.oracle.driver>
         <hikari.version>3.2.0</hikari.version>
         <org.testng.version>6.11</org.testng.version>
@@ -372,7 +396,7 @@
         <siddhi-cdc-postgres.port>5433</siddhi-cdc-postgres.port>
         <docker.container.siddhi-cdc-postgres.ip>0.0.0.0</docker.container.siddhi-cdc-postgres.ip>
         <oracle.jdbc.Driver.version>12.2.0.1</oracle.jdbc.Driver.version>
-        <kafka.connect.version>4.3.1</kafka.connect.version>
+        <kafka.connect.version>4.3.0</kafka.connect.version>
         <mongodb.connector.version>3.4.0</mongodb.connector.version>
         <json.version>20190722</json.version>
         <carbon.analytics.version>3.0.57</carbon.analytics.version>
@@ -380,6 +404,8 @@
         <com.zaxxer.hikari.version.range>[1.0.0,4.0.0)</com.zaxxer.hikari.version.range>
         <org.snake.yaml.version>2.2</org.snake.yaml.version>
         <protobuf.version>3.25.5</protobuf.version>
+        <jaxb.api.version>2.3.1</jaxb.api.version>
+        <zstd.jni.version>1.5.6-10</zstd.jni.version>
     </properties>
     <scm>
         <url>https://github.com/siddhi-io/siddhi-io-cdc.git</url>


### PR DESCRIPTION
## Summary

- `debezium` 2.7.3.Final → 3.6.1.Final — 2.7.3 is binary incompatible with Kafka 4
- `kafka-connect` 3.7.1 → 4.3.0 — the version Debezium 3.6 is built and tested against
- `log4j` → 2.25.4, `maven-shade-plugin` 3.2.1 → 3.6.2, `spotbugs` → 4.9.3.1 (JDK 21)
- **Requires a Java 17+ runtime** (Debezium 3.0 baseline). SI 4.4.0 ships Java 21.

Kafka 4 removed the deprecated `SourceTask.commitRecord(SourceRecord)`, which Debezium 2.7.3 calls on
every committed record — the first change event dies with `NoSuchMethodError`. Both `EmbeddedEngine`
and `AsyncEmbeddedEngine` in 2.7.3 call it, so only an upgrade fixes it. Reading `version.kafka` from
each `debezium-build-parent`: 3.3 is the first line on Kafka 4, 3.6.1 is the one on Kafka 4.3.

## Kafka Connect 4.x changes

- `SourceTask.commitRecord(SourceRecord)` removed — fixed by the Debezium upgrade
- `WorkerConfig` `bootstrap.servers` lost its `localhost:9092` default and is now mandatory —
  `getConfigMap()` emits a placeholder (the embedded engine never contacts a broker)
- `connect-file` version-managed to keep all Connect artifacts on one line; `slf4j-log4j12` excluded
  from `carbon.si.metrics.core` (its reload4j impl arrived via Kafka 3.x and is gone in 4.x)

## Debezium 3.x migration

- `EmbeddedEngine` removed; `AsyncEmbeddedEngine` via `ConvertingAsyncEngineBuilderFactory` is the
  only engine. The `ChangeDataCapture.getEngine()` builder chain needed no changes.
- Pinned `record.processing.order=ORDERED` and `record.processing.threads=1`. These are Debezium's
  defaults, but `handleEvent` is not thread safe, so pinning stops a future default change from
  silently making delivery concurrent.
- `META-INF/services/` SPI files regenerated from the 3.6.1 jars (bnd embeds `Private-Package`
  classes but not dependency service files): dropped 2.x-only `ConvertingEngineBuilderFactory` —
  the hard failure was `ServiceConfigurationError: Provider ... not found`; renamed
  `ConnectorMetadataProvider` → `ComponentMetadataProvider`; added `QueueProvider`; dropped the
  `Never`/`SchemaOnly` snapshotters.
- `debezium-core` is a `pom` aggregator since 3.5 — `debezium-config`, `debezium-connector-common`,
  `debezium-connect-plugins` and `debezium-util` now pack instead, absorbed by the existing
  `io.debezium:*` include.
- `SimpleSourceConnector` moved to the `tests` classifier jar — added at test scope only.

## Packaging fixes

- **OSGi manifest restored.** The shade `*:*` filter excluded `META-INF/MANIFEST.MF`, which also
  matches the project artifact, so it discarded the manifest bundle-plugin had just generated. The
  shaded jar has had no OSGi metadata since 2.1.1 (2.1.0 has one, 2.1.1 does not), which SI rejects
  with `Invalid OSGi bundle found in the lib folder` → `No extension exist for source:cdc`. PR #93's
  Jackson/MySQL relocations and `CARBON_HOME` fallback verified still intact.
- Removed stale `com.github.shyiko:mysql-binlog-connector-java:0.13.0`. Debezium never used it
  (2.7.3 resolved `com.zendesk:0.29.2`, which was not shaded at all), so the fat jar shipped a
  2016-vintage binlog client. 3.6.1's own fork packs via `io.debezium:*` and keeps the same packages.
- Pinned `javax.xml.bind:jaxb-api` 2.3.1 — 3.6.1's Oracle connector adds `jaxb-runtime` for its new
  Ehcache LogMiner buffer, whose parent pins a java.net-only build absent from Central, so resolution
  failed outright.
- Pinned `com.github.luben:zstd-jni` 1.5.6-10 — the binlog client drags 1.5.0-2, but Kafka's
  compression classes are compiled against 1.5.6-10 and are shaded in.
- New shade includes, each one a `NoClassDefFoundError` in SI: `maven-artifact` + `plexus-utils`
  (Kafka 4 `plugin.version` support), `sketches-java` (Debezium 3.x metrics),
  `zstd-jni` (`kafka.common.compress`), `jackson-module-blackbird` (registered in the merged Jackson
  `Module` service file, so `findAndRegisterModules()` fails without it).

## Breaking changes

- **Java 17+ runtime required** — cannot be back-ported to a pre-Java-17 SI release.
- **PostgreSQL listening mode now needs pgjdbc 42.7.11+.** Debezium 3.6.1 calls `ChainedCommonStreamBuilder.withAutomaticFlush(boolean)`, added to the driver between 42.7.7 and 42.7.11. The PostgreSQL driver is user-supplied in `${SI_HOME}/lib/`, so an older one fails at streaming start with `NoSuchMethodError`.
- Upstream removals worth noting since `connector.properties` is pass-through: MySQL/MariaDB `NEVER`
  snapshot mode removed in 3.6; Oracle `redo_log_catalog` deprecated for `online_catalog`.

## Test plan

- [x] 86/86 unit tests pass
- [x] New `DebeziumEngineCompatibilityTest` — runs the real engine end to end against Debezium's
      `SimpleSourceConnector` (no DB needed) and fails the build on any `LinkageError`. Nothing in the
      suite previously started the engine, leaving `WorkerConfig`, the converters, the offset store
      and the commit policy unexercised — this is the test that caught the `commitRecord` break, and
      it also proves the `InMemoryOffsetBackingStore` contract still binds.
- [x] `DebeziumConfigContractTest` extended — the three new engine keys pinned to
      `WorkerConfig.BOOTSTRAP_SERVERS_CONFIG` and `AsyncEngineConfig.RECORD_PROCESSING_{ORDER,THREADS}`,
      plus a check that `ORDERED` is still Debezium's default
- [x] SI functional suite on SI 4.4.0 — https://github.com/gayaldassanayake/wso2si-functional-tests —
      **29/29 passed**: TC39 CDC listening 13/13, TC11 CDC polling 8/8, TC07 MySQL store 7/7,
      TC35 lifecycle 3/3, TC36 `jartobundle.sh` 2/2, TC37 `osgi-lib.sh` 2/2. Remaining cases cover
      HTTP, Store API, aggregation, patterns, file, gRPC and error routing — confirming the new
      shaded payload does not disturb the rest of the runtime.
- [x] Shaded jar verified: OSGi manifest present, async engine SPI correct, exactly one
      `BinaryLogClient`, split `debezium-core` classes present

## Related issues
- https://github.com/wso2-enterprise/wso2-integration-internal/issues/5254
- https://github.com/wso2-enterprise/wso2-integration-internal/issues/5250
